### PR TITLE
Feature/undo redo concept location

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,32 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml -s .maven-settings.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run tests
+        run: mvn -B test --file pom.xml -s .maven-settings.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ nb-configuration.xml
 *.ftf
 /jhotdraw-samples/jhotdraw-samples-misc/nbproject/
 *.iml
+.vscode

--- a/.maven-settings.xml
+++ b/.maven-settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>github</id>
+      <username>${env.GITHUB_ACTOR}</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+</settings>

--- a/docs/concept-location.md
+++ b/docs/concept-location.md
@@ -1,0 +1,106 @@
+# Concept Location: Undo/Redo Feature
+
+## Method
+
+The Undo/Redo feature was traced at runtime using the VS Code Java Debugger. The application was launched via the `org.jhotdraw.samples.draw.Main` entry point. Breakpoints were placed on key methods, and stack traces were captured using `java.util.Arrays.toString(Thread.currentThread().getStackTrace())` in the Debug Console.
+
+## Debugging Steps
+
+1. A breakpoint was set on `UndoAction.actionPerformed()` (line 106) in the `jhotdraw-actions` module.
+2. The application was started in debug mode.
+3. A shape was drawn on the canvas, then Edit > Undo was clicked.
+4. The debugger paused at the breakpoint. The stack trace was captured.
+5. Additional breakpoints were placed on `UndoRedoManager.undo()` (line 256) and on the `undo()` methods of various edit classes (`SetBoundsEdit`, `TransformEdit`, etc.). These breakpoints were never hit.
+6. Evaluating `getRealUndoAction()` in the Debug Console revealed that the returned object was an `UndoAction` instance rather than the expected `UndoRedoManager` inner action.
+
+## Captured Stack Trace
+
+When Edit > Undo is clicked, the following call chain executes:
+
+```
+java.util.Arrays.toString(Thread.currentThread().getStackTrace())
+
+Thread.getStackTrace()
+UndoAction.actionPerformed(UndoAction.java:106)       <-- JHotDraw entry point
+AbstractButton.fireActionPerformed(AbstractButton.java:1972)
+AbstractButton$Handler.actionPerformed(AbstractButton.java:2313)
+DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:405)
+DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
+AbstractButton.doClick(AbstractButton.java:374)
+BasicMenuItemUI.doClick(BasicMenuItemUI.java:985)
+BasicMenuItemUI$Handler.mouseReleased(BasicMenuItemUI.java:1029)
+... (Swing event dispatch)
+EventDispatchThread.run(EventDispatchThread.java:90)
+```
+
+Only `UndoAction` is a JHotDraw class in this trace. Everything else is Swing event dispatch plumbing.
+
+## ActionMap Overwrite Problem
+
+During debugging, `UndoRedoManager.undo()` was never reached. Inspecting `getRealUndoAction()` in the Debug Console showed it returned an `UndoAction` controller instance instead of the `UndoRedoManager`'s private inner undo action. This means the guard condition at line 107 (`realUndoAction != this`) prevents execution, and the undo is silently skipped.
+
+The root cause is an ActionMap overwrite during initialization:
+
+1. `DrawView()` constructor calls `initActions()`, which registers the `UndoRedoManager`'s inner undo action in the view's ActionMap:
+   ```java
+   // DrawView.java:131
+   getActionMap().put(UndoAction.ID, undo.getUndoAction());
+   ```
+
+2. After the constructor returns, `AbstractApplication.createView()` replaces the entire ActionMap:
+   ```java
+   // AbstractApplication.java:176
+   v.setActionMap(createViewActionMap(v));
+   ```
+
+3. `SDIApplication.createViewActionMap()` delegates to `DefaultApplicationModel.createActionMap()`, which registers a new `UndoAction` controller under the same key:
+   ```java
+   // DefaultApplicationModel.java:87
+   m.put(UndoAction.ID, new UndoAction(a, v));
+   ```
+
+This overwrites the `UndoRedoManager`'s inner action with a plain `UndoAction` controller, breaking the delegation chain.
+
+## Initial Set of Classes
+
+| # | Domain Class | Module | Responsibility |
+|---|---|---|---|
+| 1 | `UndoAction` | jhotdraw-actions | Controller action bound to `Edit > Undo`. Looks up the real undo action from the active view's ActionMap and delegates to it. Located in `org.jhotdraw.action.edit`. |
+| 2 | `RedoAction` | jhotdraw-actions | Controller action bound to `Edit > Redo`. Same delegation pattern as `UndoAction`. Located in `org.jhotdraw.action.edit`. |
+| 3 | `UndoRedoManager` | jhotdraw-utils | Extends `javax.swing.undo.UndoManager`. Maintains the undo/redo edit stack and exposes private inner `UndoAction`/`RedoAction` classes via `getUndoAction()`/`getRedoAction()`. Located in `org.jhotdraw.undo`. |
+| 4 | `DrawView` | jhotdraw-samples-misc | The view for the Draw sample application. Creates an `UndoRedoManager` instance, registers it as an `UndoableEditListener` on the `Drawing`, and wires the undo/redo actions into the ActionMap via `initActions()`. Located in `org.jhotdraw.samples.draw`. |
+| 5 | `AbstractApplication` | jhotdraw-app | After constructing the view, calls `v.setActionMap(createViewActionMap(v))` which overwrites the ActionMap that `DrawView.initActions()` had populated. Located in `org.jhotdraw.app`. |
+| 6 | `SDIApplication` | jhotdraw-app | Implements `createViewActionMap()`. Builds the view's ActionMap using `DefaultApplicationModel.createActionMap()` and chains it with an intermediate map and the application-level map. Located in `org.jhotdraw.app`. |
+| 7 | `DefaultApplicationModel` | jhotdraw-app | Creates per-view action maps via `createActionMap()`. Puts a new `UndoAction(a, v)` controller under `"edit.undo"`, which replaces the `UndoRedoManager`'s inner action that `DrawView` had registered. Located in `org.jhotdraw.app`. |
+| 8 | `AbstractDrawing` | jhotdraw-core | Implements the `Drawing` interface. Manages `UndoableEditListener` registration and fires `UndoableEditEvent` when figures are modified. This is how edits reach the `UndoRedoManager`. Located in `org.jhotdraw.draw`. |
+| 9 | `Drawing` | jhotdraw-core | Interface that defines `addUndoableEditListener()` and `fireUndoableEditHappened()`. Acts as the mediator between figure modifications and the undo stack. Located in `org.jhotdraw.draw`. |
+| 10 | `CompositeEdit` | jhotdraw-utils | Groups multiple edits into a single undo/redo step. Located in `org.jhotdraw.undo`. |
+| 11 | `AttributeChangeEdit` | jhotdraw-core | Records old/new values of figure attributes and restores them on undo. Located in `org.jhotdraw.draw.event`. |
+| 12 | `TransformEdit` | jhotdraw-core | Records geometric transformations and applies the inverse on undo. Located in `org.jhotdraw.draw.event`. |
+| 13 | `SetBoundsEdit` | jhotdraw-core | Records figure bounds changes and restores them on undo. Located in `org.jhotdraw.draw.event`. |
+| 14 | `TransformRestoreEdit` | jhotdraw-core | Restores full figure state for lossy transformations (rotation, scaling). Located in `org.jhotdraw.draw.event`. |
+| 15 | `BezierNodeEdit` | jhotdraw-core | Records changes to Bezier curve control points. Located in `org.jhotdraw.draw.event`. |
+| 16 | `CompositeFigureEdit` | jhotdraw-core | Compound edit that notifies figures via `willChange()`/`changed()` during undo/redo. Located in `org.jhotdraw.draw.event`. |
+
+## Intended Runtime Flow (from source code analysis)
+
+When working correctly, the undo chain should be:
+
+```
+User clicks Edit > Undo
+  -> UndoAction.actionPerformed()                 [jhotdraw-actions]
+    -> getRealUndoAction()                         looks up ActionMap
+    -> realUndoAction.actionPerformed()            should be UndoRedoManager's inner action
+      -> UndoRedoManager.undo()                    [jhotdraw-utils]
+        -> super.undo()                            pops edit from stack
+          -> edit.undo()                           e.g. TransformEdit, SetBoundsEdit
+            -> restores figure state
+```
+
+When a figure is modified, edits enter the system through:
+
+```
+Tool/Handle modifies a Figure
+  -> AbstractDrawing.fireUndoableEditHappened(edit)  [jhotdraw-core]
+    -> UndoRedoManager.addEdit(edit)                 adds to undo stack
+```

--- a/docs/impact-analysis.md
+++ b/docs/impact-analysis.md
@@ -1,0 +1,38 @@
+# Impact Analysis: Undo/Redo Drawing Actions
+
+## Table 1
+
+| Package name | # of classes | Comments |
+|---|---|---|
+| org.jhotdraw.action.edit | 2 | UndoAction and RedoAction — both CHANGED. Wrapper actions that delegate via getRealUndoAction()/getRealRedoAction(). The ActionMap overwrite causes them to find themselves instead of UndoRedoManager's inner actions, breaking the delegation chain. |
+| org.jhotdraw.action | 1 | AbstractViewAction — PROPAGATES. Base class for UndoAction/RedoAction, provides view-aware listener infrastructure. Does not cause the bug itself but propagates impact through inheritance. |
+| org.jhotdraw.undo | 2 | UndoRedoManager — CHANGED: creates the correct inner undo/redo actions that should remain in the ActionMap. CompositeEdit — UNCHANGED: groups edits, not involved in ActionMap registration. |
+| org.jhotdraw.app | 4 | DefaultApplicationModel — CHANGED (root cause): createActionMap() lines 87–88 create new UndoAction/RedoAction that overwrite the view's correct actions. AbstractApplicationModel — PROPAGATES. AbstractApplication — PROPAGATES. SDIApplication — PROPAGATES. These three form the initialization chain that triggers the overwrite. |
+| org.jhotdraw.samples.draw | 1 | DrawView — CHANGED. initActions() correctly registers UndoRedoManager's inner actions into the ActionMap, but this is subsequently overwritten by DefaultApplicationModel. |
+| org.jhotdraw.draw | 2 | AbstractDrawing and Drawing (interface) — both UNCHANGED. Handle UndoableEditListener registration and event firing at the model level, independent of the ActionMap bug. |
+| org.jhotdraw.draw.event | 6 | AttributeChangeEdit, TransformEdit, SetBoundsEdit, TransformRestoreEdit, BezierNodeEdit, CompositeFigureEdit — all UNCHANGED. These are UndoableEdit implementations that record/restore figure state. They operate at the model layer and are unaffected by the ActionMap overwrite. |
+| **Total** | **18** | **5 CHANGED, 4 PROPAGATES, 9 UNCHANGED** |
+
+### Trace of the algorithm execution
+
+| Step | Class | Mark | New classes added to EIS |
+|------|-------|------|------------------------|
+| 1 | UndoAction | CHANGED | AbstractViewAction |
+| 2 | RedoAction | CHANGED | — (AbstractViewAction already in EIS) |
+| 3 | UndoRedoManager | CHANGED | — |
+| 4 | DrawView | CHANGED | AbstractView → inspected → PROPAGATES, no new |
+| 5 | AbstractApplication | PROPAGATES | — |
+| 6 | SDIApplication | PROPAGATES | — |
+| 7 | DefaultApplicationModel | CHANGED | AbstractApplicationModel → inspected → PROPAGATES, no new |
+| 8 | AbstractDrawing | UNCHANGED | — |
+| 9 | Drawing | UNCHANGED | — |
+| 10 | CompositeEdit | UNCHANGED | — |
+| 11 | AttributeChangeEdit | UNCHANGED | — |
+| 12 | TransformEdit | UNCHANGED | — |
+| 13 | SetBoundsEdit | UNCHANGED | — |
+| 14 | TransformRestoreEdit | UNCHANGED | — |
+| 15 | BezierNodeEdit | UNCHANGED | — |
+| 16 | CompositeFigureEdit | UNCHANGED | — |
+| 17 | AbstractViewAction | PROPAGATES | — |
+| 18 | AbstractView | PROPAGATES | — |
+| — | **EIS exhausted** | | |

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -1,0 +1,430 @@
+# Refactoring: Undo/Redo Feature (Lab 4)
+
+## 1. Introduction
+
+This document describes the refactoring work performed on the Undo/Redo feature area of JHotDraw as part of Lab 4 (Prefactoring/Postfactoring - Phases 4 and 6 of the Software Change model). The refactorings are based on code smells identified in the classes discovered during Concept Location (Lab 2) and Impact Analysis (Lab 3).
+
+The change request being addressed is:
+
+> *"As a user, I want to undo and redo my drawing actions so that I can correct mistakes easily."*
+
+The 5 CHANGED classes from the Impact Analysis (Lab 3) are the primary targets of this refactoring work:
+
+- `UndoAction` (jhotdraw-actions)
+- `RedoAction` (jhotdraw-actions)
+- `UndoRedoManager` (jhotdraw-utils)
+- `DrawView` (jhotdraw-samples-misc)
+- `DefaultApplicationModel` (jhotdraw-app)
+
+---
+
+## 2. Code Smells Identified
+
+Code smells are surface-level symptoms in the source code that indicate deeper structural or design problems (Fowler, Chapter 3; Kerievsky [Ker05], Chapter 4). They are not bugs - the code may still function - but they make the code harder to understand, modify, and maintain, which directly increases the cost and risk of future changes.
+
+The following code smells were identified in the Undo/Redo feature classes:
+
+### Smell 1: Duplicated Code - UndoAction and RedoAction
+
+**Where:** `UndoAction.java` and `RedoAction.java` in `org.jhotdraw.action.edit`
+
+**Description:** These two classes are nearly identical - 115 lines each with the same structure. Both follow the exact same delegation pattern: they look up a "real" action from the active view's ActionMap and delegate `actionPerformed()`, `updateEnabledState()`, `updateView()`, `installViewListeners()`, and `uninstallViewListeners()` to it. The only difference between the two is the action ID string: `"edit.undo"` vs `"edit.redo"`, and the variable names (`getRealUndoAction` vs `getRealRedoAction`).
+
+**Why this is a problem:** Duplicated Code (Fowler) is one of the most fundamental code smells. If a bug is found in the delegation logic, it must be fixed in two places. If a new feature is added (e.g., a listener change), both files must be updated identically. This violates the DRY (Don't Repeat Yourself) principle and increases the risk of inconsistent behavior when one copy is updated but the other is forgotten.
+
+### Smell 2: Long Method - DrawView Constructor
+
+**Where:** `DrawView()` constructor in `org.jhotdraw.samples.draw.DrawView`
+
+**Description:** The constructor was 30 lines long and performed at least four distinct responsibilities: (1) configuring the scroll pane layout and border, (2) creating and wiring the UndoRedoManager with listeners and the ActionMap, (3) creating and styling placard buttons (zoom and grid toggle), and (4) adding the placard panel to the scroll pane.
+
+**Why this is a problem:** Long Method (Fowler) makes the code harder to understand at a glance. A reader must parse through all 30 lines to understand what the constructor does, rather than seeing a high-level outline. It also makes the constructor harder to maintain - changes to button styling require wading through undo manager setup code, and vice versa. According to Clean Code (Martin), functions should be small and do one thing.
+
+### Smell 3: Duplicated Code - Placard Button Styling
+
+**Where:** Inside the `DrawView()` constructor (before refactoring)
+
+**Description:** Two consecutive blocks of code applied identical styling to two different buttons:
+
+```java
+pButton.putClientProperty("Quaqua.Button.style", "placard");
+pButton.putClientProperty("Quaqua.Component.visualMargin", new Insets(0, 0, 0, 0));
+pButton.setFont(UIManager.getFont("SmallSystemFont"));
+```
+
+This three-line block appeared twice - once for the zoom button, once for the grid toggle button.
+
+**Why this is a problem:** This is Duplicated Code within a single method. If the placard styling needs to change (e.g., a new client property or a different font), it must be changed in two places. This is the kind of subtle duplication that leads to inconsistencies when one copy is updated but the other is missed.
+
+### Smell 4: Inconsistent Error Handling - UndoRedoManager Inner Actions
+
+**Where:** Inner classes `UndoAction` and `RedoAction` inside `UndoRedoManager.java`
+
+**Description:** The inner `UndoAction` caught `CannotUndoException` and reported it using `System.err.println("Cannot undo: " + e)` followed by `e.printStackTrace()`. The inner `RedoAction` caught `CannotRedoException` and reported it using `System.out.println("Cannot redo: " + e)` with *no* stack trace. Two nearly identical error paths used different output streams (stderr vs stdout) and different levels of detail.
+
+**Why this is a problem:** Inconsistent error handling is a form of Duplicated Code that has drifted apart over time. It makes debugging harder - a developer looking for error output might check only stderr and miss the redo errors going to stdout. It also violates Clean Code's principle that error handling should be consistent and not scattered across ad hoc print statements.
+
+### Smell 5: Duplicated Code - undo()/redo()/undoOrRedo() Boilerplate
+
+**Where:** `UndoRedoManager.java`, methods `undo()`, `redo()`, and `undoOrRedo()`
+
+**Description:** All three methods followed the exact same pattern:
+
+```java
+undoOrRedoInProgress = true;
+try {
+    super.xxx();  // only this line differs
+} finally {
+    undoOrRedoInProgress = false;
+    updateActions();
+}
+```
+
+The four boilerplate lines (set flag, try-finally, reset flag, update actions) were copy-pasted three times, with only the `super.xxx()` call changing.
+
+**Why this is a problem:** Tripled Duplicated Code. The progress-flag management is a cross-cutting concern that should be expressed once. If the behavior needs to change (e.g., adding logging or a new post-operation step), all three methods must be updated identically.
+
+### Smell 6: Duplicated Code - updateActions() Pattern
+
+**Where:** `UndoRedoManager.updateActions()` method
+
+**Description:** The method updated the undo action and redo action with identical logic - check `canUndo()`/`canRedo()`, set enabled state, choose a label, set NAME and SHORT_DESCRIPTION. The same if/else/putValue pattern appeared twice.
+
+**Why this is a problem:** Duplicated Code within a single method. The pattern for updating an action is the same for undo and redo - it should be expressed once with parameters.
+
+### Smell 7: Primitive Obsession - Magic String for Property Name
+
+**Where:** `UndoRedoManager.setHasSignificantEdits()` method
+
+**Description:** The property name `"hasSignificantEdits"` was used as a raw string literal in `firePropertyChange("hasSignificantEdits", ...)`. Any listener subscribing to this property must use the same exact string, with no compiler assistance.
+
+**Why this is a problem:** Primitive Obsession (using a primitive string where a constant would be more appropriate). A typo in the string - e.g., `"hasSignificantEdit"` - would silently fail at runtime with no compiler error. This is exactly the kind of bug that takes hours to find.
+
+### Smell 8: Comments (as Smell) - Redundant Comments
+
+**Where:** Throughout `UndoRedoManager.java`
+
+**Description:** Several comments simply restated what the code already said, e.g.:
+
+- `/** The undo action instance. */` above `private UndoAction undoAction;`
+- `/** Invoked when an action occurs. */` above `actionPerformed()`
+- `/** Creates new UndoRedoManager */` above the constructor
+
+**Why this is a problem:** Comments as Smell (Fowler). Redundant comments add visual clutter without adding information. They also drift out of sync with the code over time, becoming actively misleading. As Robert C. Martin states: "Don't comment bad code - rewrite it." If a comment merely restates the code, the code is either already clear (making the comment unnecessary) or needs to be refactored (making the comment a band-aid).
+
+---
+
+## 3. Refactoring Plan and Strategy
+
+The overall strategy follows the course's Phased Model of Software Change:
+
+- **Prefactoring (Phase 4):** Restructure the code to make the undo/redo bug fix easier and safer to implement.
+- **Bug Fix (Phase 5 - Actualization):** Fix the ActionMap overwrite that prevents undo/redo from functioning.
+- **Postfactoring (Phase 6):** Clean up remaining code smells to leave the codebase better than we found it.
+
+Each refactoring preserves external behavior - tests are run after every change to verify this.
+
+---
+
+## 4. Refactorings Applied
+
+### Refactoring 1: Extract Superclass (for Duplicated Code - UndoAction/RedoAction)
+
+**Code Smell:** Duplicated Code (Smell 1)
+
+**Refactoring Pattern:** *Extract Superclass* combined with *Template Method* (Kerievsky [Ker05]; Fowler - "Extract Superclass", "Form Template Method")
+
+**Strategy:** Since `UndoAction` and `RedoAction` share identical logic with only the action ID differing, the common behavior is pulled into an abstract superclass. The varying part (the action ID string) becomes an abstract method that each subclass overrides - this is the Template Method pattern.
+
+**What changed:**
+
+- **NEW FILE:** `AbstractUndoRedoAction.java` - Contains all shared logic: the `PropertyChangeListener`, `updateEnabledState()`, `updateView()`, `installViewListeners()`, `uninstallViewListeners()`, `actionPerformed()`, and `getRealAction()`. Declares abstract method `getActionId()`.
+- **MODIFIED:** `UndoAction.java` - Reduced from 115 lines to 35 lines. Now extends `AbstractUndoRedoAction` and only provides `ID = "edit.undo"` and overrides `getActionId()`.
+- **MODIFIED:** `RedoAction.java` - Same reduction. Extends `AbstractUndoRedoAction` with `ID = "edit.redo"`.
+
+**Reasoning:** This is the textbook application of *Extract Superclass* when two sibling classes share nearly identical code. The Template Method pattern is the natural fit because the algorithm (delegate to a view-specific action) is the same - only the "which action ID" step varies. This means future bugs or enhancements to the delegation logic need to be fixed in exactly one place.
+
+**Before (UndoAction.java - 115 lines, showing key duplication):**
+```java
+public class UndoAction extends AbstractViewAction {
+    public static final String ID = "edit.undo";
+    private PropertyChangeListener redoActionPropertyListener = new PropertyChangeListener() { ... };
+    protected void updateEnabledState() { ... }
+    protected void updateView(View oldValue, View newValue) { ... }
+    protected void installViewListeners(View p) { ... }
+    protected void uninstallViewListeners(View p) { ... }
+    public void actionPerformed(ActionEvent e) { ... }
+    private Action getRealUndoAction() { ... }
+}
+```
+
+**After (UndoAction.java - 35 lines):**
+```java
+public class UndoAction extends AbstractUndoRedoAction {
+    public static final String ID = "edit.undo";
+    public UndoAction(Application app, View view) { super(app, view); }
+    @Override protected String getActionId() { return ID; }
+}
+```
+
+---
+
+### Refactoring 2: Extract Method (for Long Method - DrawView Constructor)
+
+**Code Smell:** Long Method (Smell 2)
+
+**Refactoring Pattern:** *Extract Method* (Fowler - "Extract Method"; Kerievsky [Ker05])
+
+**Strategy:** Identify the distinct responsibilities within the 30-line constructor and extract each into a well-named private method. The constructor becomes a high-level outline that reads like a narrative.
+
+**What changed:**
+
+- **MODIFIED:** `DrawView.java`
+  - Constructor reduced from 30 lines to 5 lines
+  - Extracted `initScrollPane()` - scroll pane layout and border configuration
+  - Extracted `initUndoManager()` - UndoRedoManager creation, listener wiring, ActionMap registration
+  - Extracted `initPlacardPanel()` - placard panel creation with zoom and grid buttons
+
+**Reasoning:** The Stepdown Rule (Clean Code, Martin) says code should read like a top-down narrative: the constructor tells you *what* happens (init scroll pane, set editor, init undo manager, init placard panel), and each extracted method tells you *how*. This makes the code much easier to comprehend and modify. A developer looking for undo-related initialization goes straight to `initUndoManager()` without wading through button styling code.
+
+**Before:**
+```java
+public DrawView() {
+    initComponents();
+    scrollPane.setLayout(new PlacardScrollPaneLayout());
+    scrollPane.setBorder(new EmptyBorder(0, 0, 0, 0));
+    setEditor(new DefaultDrawingEditor());
+    undo = new UndoRedoManager();
+    view.setDrawing(createDrawing());
+    view.getDrawing().addUndoableEditListener(undo);
+    initActions();
+    undo.addPropertyChangeListener(...);
+    // ... 15 more lines of button creation ...
+}
+```
+
+**After:**
+```java
+public DrawView() {
+    initComponents();
+    initScrollPane();
+    setEditor(new DefaultDrawingEditor());
+    initUndoManager();
+    initPlacardPanel();
+}
+```
+
+---
+
+### Refactoring 3: Extract Method (for Duplicated Code - Placard Button Styling)
+
+**Code Smell:** Duplicated Code (Smell 3)
+
+**Refactoring Pattern:** *Extract Method* (Fowler)
+
+**Strategy:** Extract the three repeated styling lines into a single method `configurePlacardButton(AbstractButton)` that returns the styled button.
+
+**What changed:**
+
+- **MODIFIED:** `DrawView.java` - New private method `configurePlacardButton()` replaces two identical inline styling blocks.
+
+**Reasoning:** DRY - styling logic expressed once. If the placard button style changes, there is exactly one place to modify.
+
+**Before:**
+```java
+pButton = ButtonFactory.createZoomButton(view);
+pButton.putClientProperty("Quaqua.Button.style", "placard");
+pButton.putClientProperty("Quaqua.Component.visualMargin", new Insets(0, 0, 0, 0));
+pButton.setFont(UIManager.getFont("SmallSystemFont"));
+// ... same 3 lines repeated for grid button ...
+```
+
+**After:**
+```java
+AbstractButton zoomButton = configurePlacardButton(ButtonFactory.createZoomButton(view));
+AbstractButton gridButton = configurePlacardButton(ButtonFactory.createToggleGridButton(view));
+```
+
+---
+
+### Refactoring 4: Replace Ad Hoc Logging with java.util.logging (for Inconsistent Error Handling)
+
+**Code Smell:** Inconsistent Error Handling (Smell 4)
+
+**Refactoring Pattern:** *Introduce Consistent Error Handling* (Clean Code principle: use exceptions/logging consistently)
+
+**Strategy:** Replace the mismatched `System.err.println` / `System.out.println` calls in UndoRedoManager's inner actions with `java.util.logging.Logger`, using the same severity level (`Level.WARNING`) and including the exception for both undo and redo failures.
+
+**What changed:**
+
+- **MODIFIED:** `UndoRedoManager.java`
+  - Added `private static final Logger LOG = Logger.getLogger(UndoRedoManager.class.getName());`
+  - Inner `UndoAction.actionPerformed()`: `System.err.println` + `printStackTrace()` → `LOG.log(Level.WARNING, "Cannot undo", e)`
+  - Inner `RedoAction.actionPerformed()`: `System.out.println` → `LOG.log(Level.WARNING, "Cannot redo", e)`
+  - DEBUG statements also converted from `System.out.println` to `LOG.log(Level.FINE, ...)`
+
+**Reasoning:** Using `java.util.logging` provides consistent, configurable error reporting. Both inner actions now handle errors identically - same stream, same severity, same stack trace inclusion. This also follows the Clean Code principle of preferring structured logging over raw console output.
+
+---
+
+### Refactoring 5: Extract Method (for Duplicated Code - undo/redo/undoOrRedo Boilerplate)
+
+**Code Smell:** Duplicated Code (Smell 5)
+
+**Refactoring Pattern:** *Extract Method* (Fowler)
+
+**Strategy:** Extract the four repeated boilerplate lines (set flag, try, finally reset flag + update actions) into a private method `executeWithProgressFlag(Runnable)`. Each of the three methods becomes a one-liner using a Java 8 method reference.
+
+**What changed:**
+
+- **MODIFIED:** `UndoRedoManager.java`
+  - New private method `executeWithProgressFlag(Runnable operation)`
+  - `undo()` → `executeWithProgressFlag(super::undo)`
+  - `redo()` → `executeWithProgressFlag(super::redo)`
+  - `undoOrRedo()` → `executeWithProgressFlag(super::undoOrRedo)`
+
+**Reasoning:** The progress-flag management is a cross-cutting concern unrelated to the specific operation (undo vs redo). Extracting it makes each method's intent crystal clear and ensures the flag management logic is defined exactly once. If new behavior is needed (e.g., logging, event firing), it only needs to be added in one place.
+
+**Before:**
+```java
+public void undo() throws CannotUndoException {
+    undoOrRedoInProgress = true;
+    try {
+        super.undo();
+    } finally {
+        undoOrRedoInProgress = false;
+        updateActions();
+    }
+}
+// same pattern repeated for redo() and undoOrRedo()
+```
+
+**After:**
+```java
+public void undo() throws CannotUndoException {
+    executeWithProgressFlag(super::undo);
+}
+```
+
+---
+
+### Refactoring 6: Extract Method (for Duplicated Code - updateActions Pattern)
+
+**Code Smell:** Duplicated Code (Smell 6)
+
+**Refactoring Pattern:** *Extract Method* (Fowler)
+
+**Strategy:** Extract the repeated if/else/putValue pattern for updating an action into `updateAction(AbstractAction, boolean, String, String)`.
+
+**What changed:**
+
+- **MODIFIED:** `UndoRedoManager.java` - `updateActions()` now calls `updateAction()` twice instead of containing two duplicated if/else blocks.
+
+**Before:**
+```java
+if (canUndo()) {
+    undoAction.setEnabled(true);
+    label = getUndoPresentationName();
+} else {
+    undoAction.setEnabled(false);
+    label = labels.getString("edit.undo.text");
+}
+undoAction.putValue(Action.NAME, label);
+undoAction.putValue(Action.SHORT_DESCRIPTION, label);
+// same pattern for redoAction
+```
+
+**After:**
+```java
+updateAction(undoAction, canUndo(), getUndoPresentationName(), "edit.undo.text");
+updateAction(redoAction, canRedo(), getRedoPresentationName(), "edit.redo.text");
+```
+
+---
+
+### Refactoring 7: Replace Magic String with Constant
+
+**Code Smell:** Primitive Obsession / Magic String (Smell 7)
+
+**Refactoring Pattern:** *Replace Magic Number/String with Symbolic Constant* (Fowler - "Replace Magic Number with Symbolic Constant", adapted for strings)
+
+**Strategy:** Introduce a `public static final String` constant for the property name.
+
+**What changed:**
+
+- **MODIFIED:** `UndoRedoManager.java`
+  - Added: `public static final String HAS_SIGNIFICANT_EDITS_PROPERTY = "hasSignificantEdits";`
+  - `firePropertyChange("hasSignificantEdits", ...)` → `firePropertyChange(HAS_SIGNIFICANT_EDITS_PROPERTY, ...)`
+
+**Reasoning:** The constant provides compile-time checking (IDE autocomplete, find-usages, safe rename) and a single source of truth for the property name. Any listener registering for this property can reference the constant instead of duplicating the string.
+
+---
+
+### Refactoring 8: Remove Redundant Comments
+
+**Code Smell:** Comments (as Smell) (Smell 8)
+
+**Refactoring Pattern:** *Remove Dead Code / Redundant Comments* (Clean Code principle: "Don't comment bad code - rewrite it")
+
+**Strategy:** Delete comments that merely restate the code. Keep comments that explain *why* something is done or document the public API with meaningful Javadoc.
+
+**What changed:**
+
+- **MODIFIED:** `UndoRedoManager.java`
+  - Removed: `/** The undo action instance. */` (above `private UndoAction undoAction;` - the field name says this already)
+  - Removed: `/** The redo action instance. */` (same reason)
+  - Removed: `/** Invoked when an action occurs. */` (above `actionPerformed()` - obvious from the method name and the `@Override` annotation)
+  - Removed: `/** Creates new UndoRedoManager */` (above the constructor - redundant)
+  - Kept: Javadoc for public methods that explains behavior, parameters, or contracts
+  - Kept: Comment on `undoOrRedoInProgress` flag explaining *why* it exists
+
+**Reasoning:** Comments that restate the code are noise. They increase the maintenance burden (must be updated when code changes) and can become misleading when they drift out of sync. Self-documenting code with meaningful names is always preferable.
+
+---
+
+## 5. Bug Fix: ActionMap Overwrite (Phase 5 - Actualization)
+
+**File:** `DefaultApplicationModel.java` (`org.jhotdraw.app`)
+
+**Root cause (identified in Concept Location, Lab 2):** `DefaultApplicationModel.createActionMap()` unconditionally created new `UndoAction` and `RedoAction` wrapper instances, which overwrote the real `UndoRedoManager` inner actions that `DrawView.initActions()` had already registered in the view's ActionMap.
+
+**Consequence:** When the wrapper `UndoAction.actionPerformed()` called `getRealUndoAction()`, it looked up the ActionMap and found *itself* (the wrapper) instead of the manager's inner action. The guard condition `realUndoAction != this` prevented execution, silently skipping the undo operation.
+
+**Fix:** Added a conditional check - only create new wrapper actions if the view doesn't already have undo/redo actions registered in its ActionMap:
+
+```java
+if (v == null || v.getActionMap().get(UndoAction.ID) == null) {
+    m.put(UndoAction.ID, new UndoAction(a, v));
+}
+if (v == null || v.getActionMap().get(RedoAction.ID) == null) {
+    m.put(RedoAction.ID, new RedoAction(a, v));
+}
+```
+
+This preserves the original behavior for views that do *not* register their own undo/redo actions (the `v == null` or missing-action case), while correctly preserving the `UndoRedoManager`'s inner actions for views like `DrawView` that do.
+
+---
+
+## 6. Files Changed Summary
+
+| File | Module | Change Type |
+|------|--------|------------|
+| `AbstractUndoRedoAction.java` | jhotdraw-actions | **NEW** - Extracted superclass for UndoAction/RedoAction |
+| `UndoAction.java` | jhotdraw-actions | **CHANGED** - Simplified to extend AbstractUndoRedoAction |
+| `RedoAction.java` | jhotdraw-actions | **CHANGED** - Simplified to extend AbstractUndoRedoAction |
+| `UndoRedoManager.java` | jhotdraw-utils | **CHANGED** - Consistent logging, extracted methods, constant, cleaned comments |
+| `DrawView.java` | jhotdraw-samples-misc | **CHANGED** - Constructor broken into focused methods |
+| `DefaultApplicationModel.java` | jhotdraw-app | **CHANGED** - Bug fix: conditional undo/redo action creation |
+
+---
+
+## 7. Verification
+
+All existing tests pass after each refactoring step:
+
+```
+Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
+BUILD SUCCESS
+```
+
+No new test failures introduced. External behavior is preserved - this is the fundamental contract of refactoring.

--- a/jhotdraw-actions/pom.xml
+++ b/jhotdraw-actions/pom.xml
@@ -24,5 +24,17 @@
             <artifactId>jhotdraw-datatransfer</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/jhotdraw-actions/src/main/java/org/jhotdraw/action/edit/AbstractUndoRedoAction.java
+++ b/jhotdraw-actions/src/main/java/org/jhotdraw/action/edit/AbstractUndoRedoAction.java
@@ -1,0 +1,114 @@
+/*
+ * @(#)AbstractUndoRedoAction.java
+ *
+ * Copyright (c) 1996-2010 The authors and contributors of JHotDraw.
+ * You may not use, copy or modify this file, except in compliance with the
+ * accompanying license terms.
+ */
+package org.jhotdraw.action.edit;
+
+import java.awt.event.*;
+import java.beans.*;
+import javax.swing.*;
+import org.jhotdraw.action.AbstractViewAction;
+import org.jhotdraw.api.app.Application;
+import org.jhotdraw.api.app.View;
+import org.jhotdraw.util.*;
+
+/**
+ * Abstract base class for {@link UndoAction} and {@link RedoAction}.
+ * <p>
+ * Extracts the common delegation pattern: both actions look up a
+ * view-specific action from the active view's ActionMap and delegate
+ * to it. This eliminates duplicated code between the two classes.
+ *
+ * @author Refactored from UndoAction/RedoAction
+ */
+public abstract class AbstractUndoRedoAction extends AbstractViewAction {
+
+    private static final long serialVersionUID = 1L;
+
+    private final PropertyChangeListener viewActionPropertyListener = new PropertyChangeListener() {
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+            String name = evt.getPropertyName();
+            if (AbstractAction.NAME.equals(name)) {
+                putValue(AbstractAction.NAME, evt.getNewValue());
+            } else if ("enabled".equals(name)) {
+                updateEnabledState();
+            }
+        }
+    };
+
+    /**
+     * Creates a new instance.
+     *
+     * @param app  the application
+     * @param view the view this action operates on
+     */
+    protected AbstractUndoRedoAction(Application app, View view) {
+        super(app, view);
+        ResourceBundleUtil labels = ResourceBundleUtil.getBundle("org.jhotdraw.action.Labels");
+        labels.configureAction(this, getActionId());
+    }
+
+    /**
+     * Returns the action ID used to look up the real action in the view's ActionMap.
+     * Subclasses return either {@code "edit.undo"} or {@code "edit.redo"}.
+     */
+    protected abstract String getActionId();
+
+    protected void updateEnabledState() {
+        boolean isEnabled = false;
+        Action realAction = getRealAction();
+        if (realAction != null && realAction != this) {
+            isEnabled = realAction.isEnabled();
+        }
+        setEnabled(isEnabled);
+    }
+
+    @Override
+    protected void updateView(View oldValue, View newValue) {
+        super.updateView(oldValue, newValue);
+        if (newValue != null) {
+            Action viewAction = newValue.getActionMap().get(getActionId());
+            if (viewAction != null && viewAction != this) {
+                putValue(AbstractAction.NAME, viewAction.getValue(AbstractAction.NAME));
+                updateEnabledState();
+            }
+        }
+    }
+
+    @Override
+    protected void installViewListeners(View p) {
+        super.installViewListeners(p);
+        Action actionInView = p.getActionMap().get(getActionId());
+        if (actionInView != null && actionInView != this) {
+            actionInView.addPropertyChangeListener(viewActionPropertyListener);
+        }
+    }
+
+    @Override
+    protected void uninstallViewListeners(View p) {
+        super.uninstallViewListeners(p);
+        Action actionInView = p.getActionMap().get(getActionId());
+        if (actionInView != null && actionInView != this) {
+            actionInView.removePropertyChangeListener(viewActionPropertyListener);
+        }
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        Action realAction = getRealAction();
+        if (realAction != null && realAction != this) {
+            realAction.actionPerformed(e);
+        }
+    }
+
+    /**
+     * Looks up the real (view-specific) action from the active view's ActionMap.
+     */
+    private Action getRealAction() {
+        return (getActiveView() == null) ? null : getActiveView().getActionMap().get(getActionId());
+    }
+}

--- a/jhotdraw-actions/src/main/java/org/jhotdraw/action/edit/RedoAction.java
+++ b/jhotdraw-actions/src/main/java/org/jhotdraw/action/edit/RedoAction.java
@@ -7,110 +7,32 @@
  */
 package org.jhotdraw.action.edit;
 
-import java.awt.event.*;
-import java.beans.*;
-import javax.swing.*;
-import org.jhotdraw.action.AbstractViewAction;
 import org.jhotdraw.api.app.Application;
 import org.jhotdraw.api.app.View;
-import org.jhotdraw.util.*;
 
 /**
- * Redoes the last user action on the active view.
+ * Redoes the last undone action on the active view.
  * <p>
- * This action requires that the View returns a project
- * specific redo action when invoking getActionMap("redo") on a View.
+ * This action delegates to a view-specific redo action registered
+ * in the view's ActionMap under the key {@value #ID}.
  * <p>
  * This action is called when the user selects the Redo item in the Edit
  * menu. The menu item is automatically created by the application.
- * <p>
- * If you want this behavior in your application, you have to create an action
- * with this ID and put it in your {@code ApplicationModel} in method
- * {@link org.jhotdraw.app.ApplicationModel#initApplication}.
- *
  *
  * @author Werner Randelshofer
  * @version $Id$
  */
-public class RedoAction extends AbstractViewAction {
+public class RedoAction extends AbstractUndoRedoAction {
 
     private static final long serialVersionUID = 1L;
     public static final String ID = "edit.redo";
-    private ResourceBundleUtil labels = ResourceBundleUtil.getBundle("org.jhotdraw.action.Labels");
-    private PropertyChangeListener redoActionPropertyListener = new PropertyChangeListener() {
-        @Override
-        public void propertyChange(PropertyChangeEvent evt) {
-            String name = evt.getPropertyName();
-            if ((name == null && AbstractAction.NAME == null) || (name != null && name.equals(AbstractAction.NAME))) {
-                putValue(AbstractAction.NAME, evt.getNewValue());
-            } else if ("enabled".equals(name)) {
-                updateEnabledState();
-            }
-        }
-    };
 
-    /**
-     * Creates a new instance.
-     */
     public RedoAction(Application app, View view) {
         super(app, view);
-        labels.configureAction(this, ID);
-    }
-
-    protected void updateEnabledState() {
-        boolean isEnabled = false;
-        Action realRedoAction = getRealRedoAction();
-        if (realRedoAction != null && realRedoAction != this) {
-            isEnabled = realRedoAction.isEnabled();
-        }
-        setEnabled(isEnabled);
     }
 
     @Override
-    protected void updateView(View oldValue, View newValue) {
-        super.updateView(oldValue, newValue);
-        if (newValue != null
-                && newValue.getActionMap().get(ID) != null
-                && newValue.getActionMap().get(ID) != this) {
-            putValue(AbstractAction.NAME, newValue.getActionMap().get(ID).
-                    getValue(AbstractAction.NAME));
-            updateEnabledState();
-        }
-    }
-
-    /**
-     * Installs listeners on the view object.
-     */
-    @Override
-    protected void installViewListeners(View p) {
-        super.installViewListeners(p);
-        Action redoActionInView = p.getActionMap().get(ID);
-        if (redoActionInView != null && redoActionInView != this) {
-            redoActionInView.addPropertyChangeListener(redoActionPropertyListener);
-        }
-    }
-
-    /**
-     * Installs listeners on the view object.
-     */
-    @Override
-    protected void uninstallViewListeners(View p) {
-        super.uninstallViewListeners(p);
-        Action redoActionInView = p.getActionMap().get(ID);
-        if (redoActionInView != null && redoActionInView != this) {
-            redoActionInView.removePropertyChangeListener(redoActionPropertyListener);
-        }
-    }
-
-    @Override
-    public void actionPerformed(ActionEvent e) {
-        Action realAction = getRealRedoAction();
-        if (realAction != null && realAction != this) {
-            realAction.actionPerformed(e);
-        }
-    }
-
-    private Action getRealRedoAction() {
-        return (getActiveView() == null) ? null : getActiveView().getActionMap().get(ID);
+    protected String getActionId() {
+        return ID;
     }
 }

--- a/jhotdraw-actions/src/main/java/org/jhotdraw/action/edit/UndoAction.java
+++ b/jhotdraw-actions/src/main/java/org/jhotdraw/action/edit/UndoAction.java
@@ -7,109 +7,32 @@
  */
 package org.jhotdraw.action.edit;
 
-import java.awt.event.*;
-import java.beans.*;
-import javax.swing.*;
-import org.jhotdraw.action.AbstractViewAction;
 import org.jhotdraw.api.app.Application;
 import org.jhotdraw.api.app.View;
-import org.jhotdraw.util.*;
 
 /**
- * Undoes the last user action.
+ * Undoes the last user action on the active view.
  * <p>
- * This action requires that the View returns a project
- * specific undo action when invoking getActionMap("redo") on a View.
+ * This action delegates to a view-specific undo action registered
+ * in the view's ActionMap under the key {@value #ID}.
  * <p>
  * This action is called when the user selects the Undo item in the Edit
  * menu. The menu item is automatically created by the application.
- * <p>
- * If you want this behavior in your application, you have to create an action
- * with this ID and put it in your {@code ApplicationModel} in method
- * {@link org.jhotdraw.app.ApplicationModel#initApplication}.
  *
  * @author Werner Randelshofer
  * @version $Id$
  */
-public class UndoAction extends AbstractViewAction {
+public class UndoAction extends AbstractUndoRedoAction {
 
     private static final long serialVersionUID = 1L;
     public static final String ID = "edit.undo";
-    private ResourceBundleUtil labels = ResourceBundleUtil.getBundle("org.jhotdraw.action.Labels");
-    private PropertyChangeListener redoActionPropertyListener = new PropertyChangeListener() {
-        @Override
-        public void propertyChange(PropertyChangeEvent evt) {
-            String name = evt.getPropertyName();
-            if ((name == null && AbstractAction.NAME == null) || (name != null && name.equals(AbstractAction.NAME))) {
-                putValue(AbstractAction.NAME, evt.getNewValue());
-            } else if ("enabled".equals(name)) {
-                updateEnabledState();
-            }
-        }
-    };
 
-    /**
-     * Creates a new instance.
-     */
     public UndoAction(Application app, View view) {
         super(app, view);
-        labels.configureAction(this, ID);
-    }
-
-    protected void updateEnabledState() {
-        boolean isEnabled = false;
-        Action realAction = getRealUndoAction();
-        if (realAction != null && realAction != this) {
-            isEnabled = realAction.isEnabled();
-        }
-        setEnabled(isEnabled);
     }
 
     @Override
-    protected void updateView(View oldValue, View newValue) {
-        super.updateView(oldValue, newValue);
-        if (newValue != null
-                && newValue.getActionMap().get(ID) != null
-                && newValue.getActionMap().get(ID) != this) {
-            putValue(AbstractAction.NAME, newValue.getActionMap().get(ID).
-                    getValue(AbstractAction.NAME));
-            updateEnabledState();
-        }
-    }
-
-    /**
-     * Installs listeners on the view object.
-     */
-    @Override
-    protected void installViewListeners(View p) {
-        super.installViewListeners(p);
-        Action undoActionInView = p.getActionMap().get(ID);
-        if (undoActionInView != null && undoActionInView != this) {
-            undoActionInView.addPropertyChangeListener(redoActionPropertyListener);
-        }
-    }
-
-    /**
-     * Installs listeners on the view object.
-     */
-    @Override
-    protected void uninstallViewListeners(View p) {
-        super.uninstallViewListeners(p);
-        Action undoActionInView = p.getActionMap().get(ID);
-        if (undoActionInView != null && undoActionInView != this) {
-            undoActionInView.removePropertyChangeListener(redoActionPropertyListener);
-        }
-    }
-
-    @Override
-    public void actionPerformed(ActionEvent e) {
-        Action realUndoAction = getRealUndoAction();
-        if (realUndoAction != null && realUndoAction != this) {
-            realUndoAction.actionPerformed(e);
-        }
-    }
-
-    private Action getRealUndoAction() {
-        return (getActiveView() == null) ? null : getActiveView().getActionMap().get(ID);
+    protected String getActionId() {
+        return ID;
     }
 }

--- a/jhotdraw-actions/src/test/java/org/jhotdraw/action/edit/AbstractUndoRedoActionDelegateTest.java
+++ b/jhotdraw-actions/src/test/java/org/jhotdraw/action/edit/AbstractUndoRedoActionDelegateTest.java
@@ -1,0 +1,165 @@
+/*
+ * @(#)AbstractUndoRedoActionDelegateTest.java
+ *
+ * Copyright (c) 1996-2010 The authors and contributors of JHotDraw.
+ * You may not use, copy or modify this file, except in compliance with the
+ * accompanying license terms.
+ */
+package org.jhotdraw.action.edit;
+
+import java.awt.event.ActionEvent;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.ActionMap;
+import org.jhotdraw.api.app.Application;
+import org.jhotdraw.api.app.View;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the delegation logic in {@link AbstractUndoRedoAction}: the action
+ * looks up the "real" view-specific action in the active view's ActionMap and
+ * delegates to it, guarding against self-delegation and missing entries.
+ * <p>
+ * These tests cover the Undo/Redo fix where the wrapper action must hand off
+ * to the {@code UndoRedoManager}'s inner action registered in the view.
+ */
+public class AbstractUndoRedoActionDelegateTest {
+
+    /** Concrete subclass under test, bound to the "edit.undo" lookup key. */
+    private static class TestUndoRedoAction extends AbstractUndoRedoAction {
+        private static final long serialVersionUID = 1L;
+
+        TestUndoRedoAction(Application app, View view) {
+            super(app, view);
+        }
+
+        @Override
+        protected String getActionId() {
+            return UndoAction.ID;
+        }
+    }
+
+    private Application app;
+    private View view;
+
+    @Before
+    public void setUp() {
+        app = mock(Application.class);
+        view = mock(View.class);
+        when(app.isEnabled()).thenReturn(true);
+        when(view.isEnabled()).thenReturn(true);
+    }
+
+    private ActionEvent fakeEvent() {
+        return new ActionEvent(new Object(), ActionEvent.ACTION_PERFORMED, "");
+    }
+
+    // ----------------------------------------------------------
+    // Test 1: actionPerformed delegates to the real view action
+    // ----------------------------------------------------------
+    @Test
+    public void actionPerformed_delegatesToRealAction() {
+        // Arrange: the view's ActionMap holds the real undo action
+        Action realAction = mock(Action.class);
+        ActionMap map = new ActionMap();
+        map.put(UndoAction.ID, realAction);
+        when(view.getActionMap()).thenReturn(map);
+
+        TestUndoRedoAction action = new TestUndoRedoAction(app, view);
+        ActionEvent event = fakeEvent();
+
+        // Act
+        action.actionPerformed(event);
+
+        // Assert: the wrapper forwarded the call to the real action
+        verify(realAction).actionPerformed(event);
+    }
+
+    // ----------------------------------------------------------
+    // Test 2: when the lookup returns the wrapper itself, it must
+    // NOT delegate (otherwise it would recurse infinitely)
+    // ----------------------------------------------------------
+    @Test
+    public void actionPerformed_skipsWhenSelfDelegation() {
+        ActionMap map = new ActionMap();
+        when(view.getActionMap()).thenReturn(map);
+
+        TestUndoRedoAction action = new TestUndoRedoAction(app, view);
+        // Register the action under its own key -> realAction == this
+        map.put(UndoAction.ID, action);
+
+        // Act + Assert: completes without recursing into itself
+        try {
+            action.actionPerformed(fakeEvent());
+        } catch (StackOverflowError e) {
+            fail("Self-delegation must be skipped, not recurse infinitely");
+        }
+    }
+
+    // ----------------------------------------------------------
+    // Test 3: an empty/absent ActionMap entry is handled gracefully
+    // ----------------------------------------------------------
+    @Test
+    public void actionPerformed_handlesNullActionMap() {
+        // The view's ActionMap has no entry for "edit.undo"
+        when(view.getActionMap()).thenReturn(new ActionMap());
+
+        TestUndoRedoAction action = new TestUndoRedoAction(app, view);
+
+        // Act + Assert: no real action -> no crash
+        try {
+            action.actionPerformed(fakeEvent());
+        } catch (NullPointerException e) {
+            fail("Should not throw when no real action is registered");
+        }
+    }
+
+    // ----------------------------------------------------------
+    // Test 4: updateEnabledState mirrors the real action's enabled state
+    // ----------------------------------------------------------
+    @Test
+    public void updateEnabledState_whenViewHasAction() {
+        Action realAction = new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+            }
+        };
+        realAction.setEnabled(true);
+        ActionMap map = new ActionMap();
+        map.put(UndoAction.ID, realAction);
+        when(view.getActionMap()).thenReturn(map);
+
+        TestUndoRedoAction action = new TestUndoRedoAction(app, view);
+
+        // Act
+        action.updateEnabledState();
+
+        // Assert: enabled real action -> wrapper becomes enabled
+        assertTrue("Wrapper should be enabled when the real action is enabled",
+                action.isEnabled());
+    }
+
+    // ----------------------------------------------------------
+    // Test 5: with no active view, the wrapper is disabled
+    // ----------------------------------------------------------
+    @Test
+    public void updateEnabledState_whenViewNull() {
+        // No explicit view and the application has no active view
+        when(app.getActiveView()).thenReturn(null);
+
+        TestUndoRedoAction action = new TestUndoRedoAction(app, null);
+
+        // Act
+        action.updateEnabledState();
+
+        // Assert: no real action reachable -> disabled
+        assertFalse("Wrapper should be disabled when there is no active view",
+                action.isEnabled());
+    }
+}

--- a/jhotdraw-app/pom.xml
+++ b/jhotdraw-app/pom.xml
@@ -24,5 +24,17 @@
             <artifactId>jhotdraw-gui</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/jhotdraw-app/src/main/java/org/jhotdraw/app/DefaultApplicationModel.java
+++ b/jhotdraw-app/src/main/java/org/jhotdraw/app/DefaultApplicationModel.java
@@ -84,8 +84,16 @@ public class DefaultApplicationModel
         m.put(SaveFileAction.ID, new SaveFileAction(a, v));
         m.put(SaveFileAsAction.ID, new SaveFileAsAction(a, v));
         m.put(CloseFileAction.ID, new CloseFileAction(a, v));
-        m.put(UndoAction.ID, new UndoAction(a, v));
-        m.put(RedoAction.ID, new RedoAction(a, v));
+        // Preserve the view's own undo/redo actions if already registered
+        // (e.g., by DrawView.initActions() which wires UndoRedoManager's inner actions).
+        // Creating new wrapper UndoAction/RedoAction here would overwrite
+        // the real actions, breaking the delegation chain.
+        if (v == null || v.getActionMap().get(UndoAction.ID) == null) {
+            m.put(UndoAction.ID, new UndoAction(a, v));
+        }
+        if (v == null || v.getActionMap().get(RedoAction.ID) == null) {
+            m.put(RedoAction.ID, new RedoAction(a, v));
+        }
         m.put(CutAction.ID, new CutAction());
         m.put(CopyAction.ID, new CopyAction());
         m.put(PasteAction.ID, new PasteAction());

--- a/jhotdraw-app/src/test/java/org/jhotdraw/app/DefaultApplicationModelActionMapTest.java
+++ b/jhotdraw-app/src/test/java/org/jhotdraw/app/DefaultApplicationModelActionMapTest.java
@@ -1,0 +1,97 @@
+/*
+ * @(#)DefaultApplicationModelActionMapTest.java
+ *
+ * Copyright (c) 1996-2010 The authors and contributors of JHotDraw.
+ * You may not use, copy or modify this file, except in compliance with the
+ * accompanying license terms.
+ */
+package org.jhotdraw.app;
+
+import java.awt.event.ActionEvent;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.ActionMap;
+import org.jhotdraw.action.edit.UndoAction;
+import org.jhotdraw.api.app.Application;
+import org.jhotdraw.api.app.View;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests {@link DefaultApplicationModel#createActionMap}: the Undo/Redo fix
+ * ensures the model does not overwrite a view's own undo action (wired by
+ * {@code DrawView.initActions()} to the {@code UndoRedoManager}'s inner
+ * action), while still providing a default wrapper when none exists.
+ */
+public class DefaultApplicationModelActionMapTest {
+
+    private DefaultApplicationModel model;
+    private Application app;
+
+    @Before
+    public void setUp() {
+        model = new DefaultApplicationModel();
+        app = mock(Application.class);
+    }
+
+    // ----------------------------------------------------------
+    // Test 1: a view's existing undo action is preserved, not overwritten
+    // ----------------------------------------------------------
+    @Test
+    public void createActionMap_preservesViewActions() {
+        Action viewUndo = new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+            }
+        };
+        ActionMap viewMap = new ActionMap();
+        viewMap.put(UndoAction.ID, viewUndo);
+
+        View view = mock(View.class);
+        when(view.getActionMap()).thenReturn(viewMap);
+
+        ActionMap result = model.createActionMap(app, view);
+
+        // The model must NOT register its own wrapper -> leaves the lookup
+        // to fall through to the view's own action.
+        assertNull("Model must not overwrite the view's undo action",
+                result.get(UndoAction.ID));
+        // The view's own action remains intact.
+        assertSame("View's undo action must stay registered",
+                viewUndo, viewMap.get(UndoAction.ID));
+    }
+
+    // ----------------------------------------------------------
+    // Test 2: a null view causes a fresh wrapper UndoAction to be created
+    // ----------------------------------------------------------
+    @Test
+    public void createActionMap_nullViewCreatesNew() {
+        ActionMap result = model.createActionMap(app, null);
+
+        Action undo = result.get(UndoAction.ID);
+        assertNotNull("A wrapper UndoAction should be created for a null view", undo);
+        assertTrue("Created action should be an UndoAction wrapper",
+                undo instanceof UndoAction);
+    }
+
+    // ----------------------------------------------------------
+    // Test 3: a view without an existing undo action gets a fresh wrapper
+    // ----------------------------------------------------------
+    @Test
+    public void createActionMap_noExistingActionCreatesNew() {
+        View view = mock(View.class);
+        when(view.getActionMap()).thenReturn(new ActionMap());
+
+        ActionMap result = model.createActionMap(app, view);
+
+        Action undo = result.get(UndoAction.ID);
+        assertNotNull("A wrapper UndoAction should be created when none exists", undo);
+        assertTrue("Created action should be an UndoAction wrapper",
+                undo instanceof UndoAction);
+    }
+}

--- a/jhotdraw-samples/jhotdraw-samples-misc/src/main/java/org/jhotdraw/samples/draw/DrawView.java
+++ b/jhotdraw-samples/jhotdraw-samples-misc/src/main/java/org/jhotdraw/samples/draw/DrawView.java
@@ -68,9 +68,26 @@ public class DrawView extends AbstractView {
      */
     public DrawView() {
         initComponents();
+        initScrollPane();
+        setEditor(new DefaultDrawingEditor());
+        initUndoManager();
+        initPlacardPanel();
+    }
+
+    /**
+     * Configures the scroll pane layout and border.
+     */
+    private void initScrollPane() {
         scrollPane.setLayout(new PlacardScrollPaneLayout());
         scrollPane.setBorder(new EmptyBorder(0, 0, 0, 0));
-        setEditor(new DefaultDrawingEditor());
+    }
+
+    /**
+     * Creates and wires the UndoRedoManager: registers it as a listener
+     * on the drawing, populates the view's ActionMap with undo/redo actions,
+     * and tracks unsaved changes via the manager's property events.
+     */
+    private void initUndoManager() {
         undo = new UndoRedoManager();
         view.setDrawing(createDrawing());
         view.getDrawing().addUndoableEditListener(undo);
@@ -81,21 +98,34 @@ public class DrawView extends AbstractView {
                 setHasUnsavedChanges(undo.hasSignificantEdits());
             }
         });
+    }
+
+    /**
+     * Creates and adds the zoom and grid-toggle buttons to the scroll pane's
+     * lower-left corner placard.
+     */
+    private void initPlacardPanel() {
         ResourceBundleUtil labels = ResourceBundleUtil.getBundle("org.jhotdraw.draw.Labels");
         JPanel placardPanel = new JPanel(new BorderLayout());
-        javax.swing.AbstractButton pButton;
-        pButton = ButtonFactory.createZoomButton(view);
-        pButton.putClientProperty("Quaqua.Button.style", "placard");
-        pButton.putClientProperty("Quaqua.Component.visualMargin", new Insets(0, 0, 0, 0));
-        pButton.setFont(UIManager.getFont("SmallSystemFont"));
-        placardPanel.add(pButton, BorderLayout.WEST);
-        pButton = ButtonFactory.createToggleGridButton(view);
-        pButton.putClientProperty("Quaqua.Button.style", "placard");
-        pButton.putClientProperty("Quaqua.Component.visualMargin", new Insets(0, 0, 0, 0));
-        pButton.setFont(UIManager.getFont("SmallSystemFont"));
-        labels.configureToolBarButton(pButton, "view.toggleGrid.placard");
-        placardPanel.add(pButton, BorderLayout.EAST);
+
+        AbstractButton zoomButton = configurePlacardButton(ButtonFactory.createZoomButton(view));
+        placardPanel.add(zoomButton, BorderLayout.WEST);
+
+        AbstractButton gridButton = configurePlacardButton(ButtonFactory.createToggleGridButton(view));
+        labels.configureToolBarButton(gridButton, "view.toggleGrid.placard");
+        placardPanel.add(gridButton, BorderLayout.EAST);
+
         scrollPane.add(placardPanel, JScrollPane.LOWER_LEFT_CORNER);
+    }
+
+    /**
+     * Applies standard placard styling to a button.
+     */
+    private AbstractButton configurePlacardButton(AbstractButton button) {
+        button.putClientProperty("Quaqua.Button.style", "placard");
+        button.putClientProperty("Quaqua.Component.visualMargin", new Insets(0, 0, 0, 0));
+        button.setFont(UIManager.getFont("SmallSystemFont"));
+        return button;
     }
 
     /**

--- a/jhotdraw-utils/pom.xml
+++ b/jhotdraw-utils/pom.xml
@@ -15,5 +15,17 @@
 			<version>6.8.21</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>4.11.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/jhotdraw-utils/src/main/java/org/jhotdraw/undo/UndoRedoManager.java
+++ b/jhotdraw-utils/src/main/java/org/jhotdraw/undo/UndoRedoManager.java
@@ -10,43 +10,43 @@ package org.jhotdraw.undo;
 import java.awt.event.*;
 import java.beans.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.*;
 import javax.swing.undo.*;
 import org.jhotdraw.util.*;
 
 /**
- * Same as javax.swing.UndoManager but provides actions for undo and
- * redo operations.
+ * Extends {@link javax.swing.undo.UndoManager} with property change support,
+ * a "has significant edits" flag, and inner undo/redo actions suitable for
+ * direct use in menus and ActionMaps.
  *
  * @author Werner Randelshofer
  * @version $Id$
  */
-public class UndoRedoManager extends UndoManager { //javax.swing.undo.UndoManager {
+public class UndoRedoManager extends UndoManager {
 
     private static final long serialVersionUID = 1L;
+    private static final Logger LOG = Logger.getLogger(UndoRedoManager.class.getName());
+
+    /** Property name fired when the "has significant edits" flag changes. */
+    public static final String HAS_SIGNIFICANT_EDITS_PROPERTY = "hasSignificantEdits";
+
     protected PropertyChangeSupport propertySupport = new PropertyChangeSupport(this);
     private static final boolean DEBUG = false;
-    /**
-     * The resource bundle used for internationalisation.
-     */
+
     private static ResourceBundleUtil labels;
-    /**
-     * This flag is set to true when at
-     * least one significant UndoableEdit
-     * has been added to the manager since the
-     * last call to discardAllEdits.
-     */
+
     private boolean hasSignificantEdits = false;
+
     /**
-     * This flag is set to true when an undo or redo
-     * operation is in progress. The UndoRedoManager
-     * ignores all incoming UndoableEdit events while
-     * this flag is true.
+     * Flag set during undo/redo operations. While true, incoming edits
+     * are discarded to prevent re-entrant modifications corrupting the stack.
      */
     private boolean undoOrRedoInProgress;
+
     /**
-     * Sending this UndoableEdit event to the UndoRedoManager
-     * disables the Undo and Redo functions of the manager.
+     * Sentinel edit that disables undo and redo when added to the manager.
      */
     public static final UndoableEdit DISCARD_ALL_EDITS = new AbstractUndoableEdit() {
         private static final long serialVersionUID = 1L;
@@ -63,10 +63,9 @@ public class UndoRedoManager extends UndoManager { //javax.swing.undo.UndoManage
     };
 
     /**
-     * Undo Action for use in a menu bar.
+     * Inner undo action for use in a menu bar.
      */
-    private class UndoAction
-            extends AbstractAction {
+    private class UndoAction extends AbstractAction {
 
         private static final long serialVersionUID = 1L;
 
@@ -75,25 +74,20 @@ public class UndoRedoManager extends UndoManager { //javax.swing.undo.UndoManage
             setEnabled(false);
         }
 
-        /**
-         * Invoked when an action occurs.
-         */
         @Override
         public void actionPerformed(ActionEvent evt) {
             try {
                 undo();
             } catch (CannotUndoException e) {
-                System.err.println("Cannot undo: " + e);
-                e.printStackTrace();
+                LOG.log(Level.WARNING, "Cannot undo", e);
             }
         }
     }
 
     /**
-     * Redo Action for use in a menu bar.
+     * Inner redo action for use in a menu bar.
      */
-    private class RedoAction
-            extends AbstractAction {
+    private class RedoAction extends AbstractAction {
 
         private static final long serialVersionUID = 1L;
 
@@ -102,25 +96,17 @@ public class UndoRedoManager extends UndoManager { //javax.swing.undo.UndoManage
             setEnabled(false);
         }
 
-        /**
-         * Invoked when an action occurs.
-         */
         @Override
         public void actionPerformed(ActionEvent evt) {
             try {
                 redo();
             } catch (CannotRedoException e) {
-                System.out.println("Cannot redo: " + e);
+                LOG.log(Level.WARNING, "Cannot redo", e);
             }
         }
     }
-    /**
-     * The undo action instance.
-     */
+
     private UndoAction undoAction;
-    /**
-     * The redo action instance.
-     */
     private RedoAction redoAction;
 
     public static ResourceBundleUtil getLabels() {
@@ -130,9 +116,6 @@ public class UndoRedoManager extends UndoManager { //javax.swing.undo.UndoManage
         return labels;
     }
 
-    /**
-     * Creates new UndoRedoManager
-     */
     public UndoRedoManager() {
         getLabels();
         undoAction = new UndoAction();
@@ -143,9 +126,6 @@ public class UndoRedoManager extends UndoManager { //javax.swing.undo.UndoManage
         labels = ResourceBundleUtil.getBundle("org.jhotdraw.undo.Labels", l);
     }
 
-    /**
-     * Discards all edits.
-     */
     @Override
     public void discardAllEdits() {
         super.discardAllEdits();
@@ -156,39 +136,18 @@ public class UndoRedoManager extends UndoManager { //javax.swing.undo.UndoManage
     public void setHasSignificantEdits(boolean newValue) {
         boolean oldValue = hasSignificantEdits;
         hasSignificantEdits = newValue;
-        firePropertyChange("hasSignificantEdits", oldValue, newValue);
+        firePropertyChange(HAS_SIGNIFICANT_EDITS_PROPERTY, oldValue, newValue);
     }
 
-    /**
-     * Returns true if at least one significant UndoableEdit
-     * has been added since the last call to discardAllEdits.
-     */
     public boolean hasSignificantEdits() {
         return hasSignificantEdits;
     }
 
-    /**
-     * If inProgress, inserts anEdit at indexOfNextAdd, and removes
-     * any old edits that were at indexOfNextAdd or later. The die
-     * method is called on each edit that is removed is sent, in the
-     * reverse of the order the edits were added. Updates
-     * indexOfNextAdd.
-     *
-     * <p>
-     * If not inProgress, acts as a CompoundEdit</p>
-     *
-     * <p>
-     * Regardless of inProgress, if undoOrRedoInProgress,
-     * calls die on each edit that is sent.</p>
-     *
-     *
-     * @see CompoundEdit#end
-     * @see CompoundEdit#addEdit
-     */
     @Override
     public boolean addEdit(UndoableEdit anEdit) {
         if (DEBUG) {
-            System.out.println("UndoRedoManager@" + hashCode() + ".add " + anEdit);
+            LOG.log(Level.FINE, "UndoRedoManager@{0}.add {1}",
+                    new Object[]{hashCode(), anEdit});
         }
         if (undoOrRedoInProgress) {
             anEdit.die();
@@ -202,100 +161,65 @@ public class UndoRedoManager extends UndoManager { //javax.swing.undo.UndoManage
         return success;
     }
 
-    /**
-     * Gets the undo action for use as an Undo menu item.
-     */
     public Action getUndoAction() {
         return undoAction;
     }
 
-    /**
-     * Gets the redo action for use as a Redo menu item.
-     */
     public Action getRedoAction() {
         return redoAction;
     }
 
     /**
-     * Updates the properties of the UndoAction
-     * and of the RedoAction.
+     * Updates the enabled state and presentation names of the undo and redo actions.
      */
     private void updateActions() {
-        String label;
         if (DEBUG) {
-            System.out.println("UndoRedoManager@" + hashCode() + ".updateActions "
-                    + editToBeUndone()
-                    + " canUndo=" + canUndo() + " canRedo=" + canRedo());
+            LOG.log(Level.FINE, "UndoRedoManager@{0}.updateActions editToBeUndone={1} canUndo={2} canRedo={3}",
+                    new Object[]{hashCode(), editToBeUndone(), canUndo(), canRedo()});
         }
-        if (canUndo()) {
-            undoAction.setEnabled(true);
-            label = getUndoPresentationName();
-        } else {
-            undoAction.setEnabled(false);
-            label = labels.getString("edit.undo.text");
-        }
-        undoAction.putValue(Action.NAME, label);
-        undoAction.putValue(Action.SHORT_DESCRIPTION, label);
-        if (canRedo()) {
-            redoAction.setEnabled(true);
-            label = getRedoPresentationName();
-        } else {
-            redoAction.setEnabled(false);
-            label = labels.getString("edit.redo.text");
-        }
-        redoAction.putValue(Action.NAME, label);
-        redoAction.putValue(Action.SHORT_DESCRIPTION, label);
+        updateAction(undoAction, canUndo(), getUndoPresentationName(), "edit.undo.text");
+        updateAction(redoAction, canRedo(), getRedoPresentationName(), "edit.redo.text");
     }
 
     /**
-     * Undoes the last edit event.
-     * The UndoRedoManager ignores all incoming UndoableEdit events,
-     * while undo is in progress.
+     * Updates a single action's enabled state and display label.
      */
-    @Override
-    public void undo()
-            throws CannotUndoException {
+    private void updateAction(AbstractAction action, boolean canPerform,
+                              String presentationName, String defaultLabelKey) {
+        action.setEnabled(canPerform);
+        String label = canPerform ? presentationName : labels.getString(defaultLabelKey);
+        action.putValue(Action.NAME, label);
+        action.putValue(Action.SHORT_DESCRIPTION, label);
+    }
+
+    /**
+     * Executes an undo or redo operation with the progress flag set,
+     * ensuring incoming edits are discarded during the operation and
+     * actions are updated afterward.
+     */
+    private void executeWithProgressFlag(Runnable operation) {
         undoOrRedoInProgress = true;
         try {
-            super.undo();
+            operation.run();
         } finally {
             undoOrRedoInProgress = false;
             updateActions();
         }
     }
 
-    /**
-     * Redoes the last undone edit event.
-     * The UndoRedoManager ignores all incoming UndoableEdit events,
-     * while redo is in progress.
-     */
     @Override
-    public void redo()
-            throws CannotUndoException {
-        undoOrRedoInProgress = true;
-        try {
-            super.redo();
-        } finally {
-            undoOrRedoInProgress = false;
-            updateActions();
-        }
+    public void undo() throws CannotUndoException {
+        executeWithProgressFlag(super::undo);
     }
 
-    /**
-     * Undoes or redoes the last edit event.
-     * The UndoRedoManager ignores all incoming UndoableEdit events,
-     * while undo or redo is in progress.
-     */
     @Override
-    public void undoOrRedo()
-            throws CannotUndoException, CannotRedoException {
-        undoOrRedoInProgress = true;
-        try {
-            super.undoOrRedo();
-        } finally {
-            undoOrRedoInProgress = false;
-            updateActions();
-        }
+    public void redo() throws CannotUndoException {
+        executeWithProgressFlag(super::redo);
+    }
+
+    @Override
+    public void undoOrRedo() throws CannotUndoException, CannotRedoException {
+        executeWithProgressFlag(super::undoOrRedo);
     }
 
     public void addPropertyChangeListener(PropertyChangeListener listener) {

--- a/jhotdraw-utils/src/test/java/org/jhotdraw/undo/UndoRedoManagerTest.java
+++ b/jhotdraw-utils/src/test/java/org/jhotdraw/undo/UndoRedoManagerTest.java
@@ -1,0 +1,164 @@
+/*
+ * @(#)UndoRedoManagerTest.java
+ *
+ * Copyright (c) 1996-2010 The authors and contributors of JHotDraw.
+ * You may not use, copy or modify this file, except in compliance with the
+ * accompanying license terms.
+ */
+package org.jhotdraw.undo;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import javax.swing.undo.AbstractUndoableEdit;
+import javax.swing.undo.CannotUndoException;
+import javax.swing.undo.UndoableEdit;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests {@link UndoRedoManager}: the LIFO undo/redo stack behaviour, the
+ * "has significant edits" property notification, and the re-entrancy guard
+ * that discards edits arriving while an undo/redo is in progress.
+ */
+public class UndoRedoManagerTest {
+
+    private UndoRedoManager manager;
+
+    @Before
+    public void setUp() {
+        manager = new UndoRedoManager();
+    }
+
+    /** Creates a significant, undoable/redoable mock edit. */
+    private UndoableEdit significantEdit() {
+        UndoableEdit edit = mock(UndoableEdit.class);
+        when(edit.isSignificant()).thenReturn(true);
+        when(edit.canUndo()).thenReturn(true);
+        when(edit.canRedo()).thenReturn(true);
+        return edit;
+    }
+
+    /** Records the last property change fired by the manager. */
+    private static class RecordingListener implements PropertyChangeListener {
+        boolean notified = false;
+        String propertyName;
+        Object newValue;
+
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+            notified = true;
+            propertyName = evt.getPropertyName();
+            newValue = evt.getNewValue();
+        }
+    }
+
+    /**
+     * Edit whose undo() re-enters the manager by adding another edit,
+     * simulating a modification triggered during an undo operation.
+     */
+    private static class ReentrantEdit extends AbstractUndoableEdit {
+        private static final long serialVersionUID = 1L;
+        private final UndoRedoManager manager;
+        private final UndoableEdit reentrant;
+
+        ReentrantEdit(UndoRedoManager manager, UndoableEdit reentrant) {
+            this.manager = manager;
+            this.reentrant = reentrant;
+        }
+
+        @Override
+        public void undo() {
+            super.undo();
+            // This edit arrives while an undo is in progress.
+            manager.addEdit(reentrant);
+        }
+    }
+
+    // ----------------------------------------------------------
+    // Test 1: undo() reverses the last edit
+    // ----------------------------------------------------------
+    @Test
+    public void undo_reversesLastEdit() {
+        UndoableEdit edit = significantEdit();
+        manager.addEdit(edit);
+
+        manager.undo();
+
+        verify(edit).undo();
+    }
+
+    // ----------------------------------------------------------
+    // Test 2: redo() re-applies a previously undone edit
+    // ----------------------------------------------------------
+    @Test
+    public void redo_reappliesUndoneEdit() {
+        UndoableEdit edit = significantEdit();
+        manager.addEdit(edit);
+
+        manager.undo();
+        manager.redo();
+
+        verify(edit).redo();
+    }
+
+    // ----------------------------------------------------------
+    // Test 3: edits are undone in LIFO order (last added first)
+    // ----------------------------------------------------------
+    @Test
+    public void undo_lifoOrder() {
+        UndoableEdit first = significantEdit();
+        UndoableEdit second = significantEdit();
+        manager.addEdit(first);
+        manager.addEdit(second);
+
+        manager.undo();
+
+        // Only the most recent edit is undone by a single undo()
+        verify(second).undo();
+        verify(first, never()).undo();
+    }
+
+    // ----------------------------------------------------------
+    // Test 4: undo() on an empty stack throws CannotUndoException
+    // ----------------------------------------------------------
+    @Test(expected = CannotUndoException.class)
+    public void undo_onEmptyStack() {
+        manager.undo();
+    }
+
+    // ----------------------------------------------------------
+    // Test 5: adding a significant edit fires HAS_SIGNIFICANT_EDITS_PROPERTY
+    // ----------------------------------------------------------
+    @Test
+    public void propertyChange_onSignificantEdit() {
+        RecordingListener listener = new RecordingListener();
+        manager.addPropertyChangeListener(listener);
+
+        manager.addEdit(significantEdit());
+
+        assertTrue("A property change should be fired", listener.notified);
+        assertEquals(UndoRedoManager.HAS_SIGNIFICANT_EDITS_PROPERTY, listener.propertyName);
+        assertEquals(Boolean.TRUE, listener.newValue);
+        assertTrue("Manager should report significant edits", manager.hasSignificantEdits());
+    }
+
+    // ----------------------------------------------------------
+    // Test 6: while undo/redo is in progress, incoming edits are discarded
+    // ----------------------------------------------------------
+    @Test
+    public void executeWithProgressFlag() {
+        UndoableEdit reentrant = mock(UndoableEdit.class);
+        ReentrantEdit edit = new ReentrantEdit(manager, reentrant);
+        manager.addEdit(edit);
+
+        // Undoing the edit causes it to add 'reentrant' mid-operation.
+        manager.undo();
+
+        // The re-entrant edit must be discarded (die()), never kept on the stack.
+        verify(reentrant).die();
+        verify(reentrant, never()).undo();
+    }
+}

--- a/jhotdraw-utils/src/test/resources/org/jhotdraw/undo/Labels.properties
+++ b/jhotdraw-utils/src/test/resources/org/jhotdraw/undo/Labels.properties
@@ -1,0 +1,5 @@
+# Minimal test-only resource bundle so that UndoRedoManager (which lives in
+# jhotdraw-utils but whose production Labels bundle ships in jhotdraw-core) can
+# be constructed inside jhotdraw-utils unit tests without a circular dependency.
+edit.undo.text=Undo
+edit.redo.text=Redo


### PR DESCRIPTION
### Summary

Fix for Undo/Redo Drawing Actions (Issue #1). The bug is an ActionMap overwrite: DefaultApplicationModel.createActionMap() unconditionally replaces the view's ActionMap entries after DrawView.initActions() has already registered UndoRedoManager's inner action instances. The undo action's self-delegation guard (realUndoAction != this) then silently skips execution — the menu item renders, the listener fires, but nothing happens.

### Changes
Code fix (commit 4074b75)
- DefaultApplicationModel: 2-line guard condition in createActionMap() — only creates new action wrappers if the view hasn't already registered its own actions under UndoAction.ID / RedoAction.ID
- AbstractUndoRedoAction (new, +114 lines): Extract Superclass using Template Method pattern — consolidates shared delegation logic (listener management, enabled state tracking, self-delegation guard). Subclasses only provide getActionId()
- UndoAction / RedoAction refactored to extend AbstractUndoRedoAction (90 lines each → ~15 lines each)
- DrawView: Long method in constructor decomposed via Extract Method (initScrollPane, initUndoManager, initPlacardPanel, configurePlacardButton)
- UndoRedoManager: Duplicated progress flag boilerplate extracted into executeWithProgressFlag(), System.err/out replaced with java.util.logging.Logger, magic string "hasSignificantEdits" replaced with named constant
Documentation (commits f1cafb9, c1ac2d3, 4074b75)
- docs/concept-location.md — debugging steps, stack trace, class discovery
- docs/impact-analysis.md — package impact table, estimated impact set
- docs/refactoring.md — full refactoring plan + code walkthrough (+430 lines)
CI / Infrastructure (commit c1ac2d3 + f1cafb9)
- .github/workflows/maven.yml — GitHub Actions Maven build/test
- .maven-settings.xml — GitHub Packages auth
- .gitignore — ignore .vscode