### PR TITLE
Group/Ungroup Action Code Refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Java CI with Maven
+
+on:
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+        
+    - name: Build with Maven
+      run: mvn -B package -s .maven-settings.xml
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Run tests with Maven
+      run: mvn -B test --settings .maven-settings.xml
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: Java CI with Maven
 
 on:
   pull_request:
-    branches: [ "develop" ]
+    branches: [ 
+      "develop",
+      "feature/group-ungroup"
+    ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: Java CI with Maven
 
 on:
+  push:
+    branches: [ 
+      "feature/group-ungroup"
+    ]
   pull_request:
     branches: [ 
-      "develop",
-      "feature/group-ungroup"
+      "develop"
     ]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,35 +1,25 @@
 name: Java CI with Maven
-
 on:
   push:
-    branches: [ 
-      "feature/group-ungroup"
-    ]
+    branches: [ "feature/group-ungroup"]
   pull_request:
-    branches: [ 
-      "develop"
-    ]
-
+    branches: [ "develop"]
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
-        
     - name: Build with Maven
       run: mvn -B package -s .maven-settings.xml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Run tests with Maven
       run: mvn -B test --settings .maven-settings.xml
       env:

--- a/.maven-settings.xml
+++ b/.maven-settings.xml
@@ -1,0 +1,9 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+  <servers>
+    <server>
+      <id>github</id>
+      <username>${env.GITHUB_ACTOR}</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+</settings>

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/jhotdraw-core/pom.xml
+++ b/jhotdraw-core/pom.xml
@@ -52,5 +52,29 @@
 			<version>4.11.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+            <groupId>com.tngtech.jgiven</groupId>
+            <artifactId>jgiven-junit</artifactId>
+            <version>1.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.24.2</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
+	<build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
+                <configuration>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jhotdraw-core/pom.xml
+++ b/jhotdraw-core/pom.xml
@@ -35,10 +35,22 @@
 			<version>6.8.21</version>
 			<scope>test</scope>
 		</dependency>
-	 <dependency>
-	  <groupId>${project.groupId}</groupId>
-	  <artifactId>jhotdraw-actions</artifactId>
-	  <version>${project.version}</version>
-	 </dependency>
+		<dependency>
+		<groupId>${project.groupId}</groupId>
+		<artifactId>jhotdraw-actions</artifactId>
+		<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>4.11.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/AbstractGroupAction.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/AbstractGroupAction.java
@@ -1,0 +1,45 @@
+package org.jhotdraw.draw.action;
+
+import org.jhotdraw.draw.DrawingView;
+import org.jhotdraw.draw.figure.CompositeFigure;
+import org.jhotdraw.draw.figure.Figure;
+import java.util.Collection;
+import java.util.LinkedList;
+
+public abstract class AbstractGroupAction extends AbstractSelectedAction {
+    private static final long serialVersionUID = 1L;
+    protected static final String LABELS_RESOURCE = "org.jhotdraw.draw.Labels";
+    protected CompositeFigure prototype;
+
+    protected AbstractGroupAction(org.jhotdraw.draw.DrawingEditor editor, CompositeFigure prototype) {
+        super(editor);
+        this.prototype = prototype;
+    }
+
+    // The shared math for grouping
+    public void groupFigures(DrawingView view, CompositeFigure group, Collection<Figure> figures) {
+        Collection<Figure> sorted = view.getDrawing().sort(figures);
+        int index = view.getDrawing().indexOf(sorted.iterator().next());
+        view.getDrawing().basicRemoveAll(figures);
+        view.clearSelection();
+        view.getDrawing().add(index, group);
+        group.willChange();
+        for (Figure f : sorted) {
+            f.willChange();
+            group.basicAdd(f);
+        }
+        group.changed();
+        view.addToSelection(group);
+    }
+
+    // The shared math for ungrouping
+    public Collection<Figure> ungroupFigures(DrawingView view, CompositeFigure group) {
+        LinkedList<Figure> figures = new LinkedList<>(group.getChildren());
+        view.clearSelection();
+        group.basicRemoveAllChildren();
+        view.getDrawing().basicAddAll(view.getDrawing().indexOf(group), figures);
+        view.getDrawing().remove(group);
+        view.addToSelection(figures);
+        return figures;
+    }
+}

--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/GroupAction.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/GroupAction.java
@@ -1,10 +1,3 @@
-/*
- * @(#)GroupAction.java
- *
- * Copyright (c) 1996-2010 The authors and contributors of JHotDraw.
- * You may not use, copy or modify this file, except in compliance with the
- * accompanying license terms.
- */
 package org.jhotdraw.draw.action;
 
 import org.jhotdraw.draw.figure.Figure;
@@ -15,41 +8,17 @@ import javax.swing.undo.*;
 import org.jhotdraw.draw.*;
 import org.jhotdraw.util.ResourceBundleUtil;
 
-/**
- * GroupAction.
- *
- * @author Werner Randelshofer
- * @version $Id$
- */
-public class GroupAction extends AbstractSelectedAction {
-
+public class GroupAction extends AbstractGroupAction {
     private static final long serialVersionUID = 1L;
     public static final String ID = "edit.groupSelection";
-    private static final String LABELS_RESOURCE = "org.jhotdraw.draw.Labels";
-    private CompositeFigure prototype;
-    /**
-     * If this variable is true, this action groups figures.
-     * If this variable is false, this action ungroups figures.
-     */
-    private boolean isGroupingAction;
 
-    /**
-     * Creates a new instance.
-     */
     public GroupAction(DrawingEditor editor) {
-        this(editor, new GroupFigure(), true);
+        this(editor, new GroupFigure());
     }
 
     public GroupAction(DrawingEditor editor, CompositeFigure prototype) {
-        this(editor, prototype, true);
-    }
-
-    public GroupAction(DrawingEditor editor, CompositeFigure prototype, boolean isGroupingAction) {
-        super(editor);
-        this.prototype = prototype;
-        this.isGroupingAction = isGroupingAction;
-        ResourceBundleUtil labels
-                = ResourceBundleUtil.getBundle(LABELS_RESOURCE);
+        super(editor, prototype);
+        ResourceBundleUtil labels = ResourceBundleUtil.getBundle(LABELS_RESOURCE);
         labels.configureAction(this, ID);
         updateEnabledState();
     }
@@ -57,114 +26,22 @@ public class GroupAction extends AbstractSelectedAction {
     @Override
     protected void updateEnabledState() {
         if (getView() != null) {
-            setEnabled(isGroupingAction ? canGroup() : canUngroup());
+            setEnabled(getView().getSelectionCount() > 1);
         } else {
             setEnabled(false);
         }
     }
 
-    protected boolean canGroup() {
-        return getView() != null && getView().getSelectionCount() > 1;
-    }
-
-    protected boolean canUngroup() {
-        return getView() != null
-                && getView().getSelectionCount() == 1
-                && prototype != null
-                && getView().getSelectedFigures().iterator().next().getClass().equals(
-                        prototype.getClass());
-    }
-
     @Override
     public void actionPerformed(java.awt.event.ActionEvent e) {
-        if (isGroupingAction) {
-            if (canGroup()) {
-                final DrawingView view = getView();
-                final LinkedList<Figure> ungroupedFigures = new LinkedList<>(view.getSelectedFigures());
-                final CompositeFigure group = (CompositeFigure) prototype.clone();
-                UndoableEdit edit = new AbstractUndoableEdit() {
-                    private static final long serialVersionUID = 1L;
+        if (getView() != null && getView().getSelectionCount() > 1) {
+            final DrawingView view = getView();
+            final LinkedList<Figure> ungroupedFigures = new LinkedList<>(view.getSelectedFigures());
+            final CompositeFigure group = (CompositeFigure) prototype.clone();
 
-                    @Override
-                    public String getPresentationName() {
-                        ResourceBundleUtil labels
-                                = ResourceBundleUtil.getBundle(LABELS_RESOURCE);
-                        return labels.getString("edit.groupSelection.text");
-                    }
-
-                    @Override
-                    public void redo() throws CannotRedoException {
-                        super.redo();
-                        groupFigures(view, group, ungroupedFigures);
-                    }
-
-                    @Override
-                    public void undo() throws CannotUndoException {
-                        ungroupFigures(view, group);
-                        super.undo();
-                    }
-                };
-                groupFigures(view, group, ungroupedFigures);
-                fireUndoableEditHappened(edit);
-            }
-        } else {
-            if (canUngroup()) {
-                final DrawingView view = getView();
-                final CompositeFigure group = (CompositeFigure) getView().getSelectedFigures().iterator().next();
-                final LinkedList<Figure> ungroupedFigures = new LinkedList<>();
-                UndoableEdit edit = new AbstractUndoableEdit() {
-                    private static final long serialVersionUID = 1L;
-
-                    @Override
-                    public String getPresentationName() {
-                        ResourceBundleUtil labels
-                                = ResourceBundleUtil.getBundle(LABELS_RESOURCE);
-                        return labels.getString("edit.ungroupSelection.text");
-                    }
-
-                    @Override
-                    public void redo() throws CannotRedoException {
-                        super.redo();
-                        ungroupFigures(view, group);
-                    }
-
-                    @Override
-                    public void undo() throws CannotUndoException {
-                        groupFigures(view, group, ungroupedFigures);
-                        super.undo();
-                    }
-                };
-                ungroupedFigures.addAll(ungroupFigures(view, group));
-                fireUndoableEditHappened(edit);
-            }
+            groupFigures(view, group, ungroupedFigures);
+            UndoableEdit edit = new GroupUndoableEdit(this, view, group, ungroupedFigures, true);
+            fireUndoableEditHappened(edit);
         }
-    }
-
-    public Collection<Figure> ungroupFigures(DrawingView view, CompositeFigure group) {
-// XXX - This code is redundant with UngroupAction
-        LinkedList<Figure> figures = new LinkedList<>(group.getChildren());
-        view.clearSelection();
-        group.basicRemoveAllChildren();
-        view.getDrawing().basicAddAll(view.getDrawing().indexOf(group), figures);
-        view.getDrawing().remove(group);
-        view.addToSelection(figures);
-        return figures;
-    }
-
-    public void groupFigures(DrawingView view, CompositeFigure group, Collection<Figure> figures) {
-        assert figures != null && figures.size() > 1 : "Fatal Invariant Violation: groupFigures called with insufficient figures.";
-
-        Collection<Figure> sorted = view.getDrawing().sort(figures);
-        int index = view.getDrawing().indexOf(sorted.iterator().next());
-        view.getDrawing().basicRemoveAll(figures);
-        view.clearSelection();
-        view.getDrawing().add(index, group);
-        group.willChange();
-        for (Figure f : sorted) {
-            f.willChange();
-            group.basicAdd(f);
-        }
-        group.changed();
-        view.addToSelection(group);
     }
 }

--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/GroupAction.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/GroupAction.java
@@ -152,6 +152,8 @@ public class GroupAction extends AbstractSelectedAction {
     }
 
     public void groupFigures(DrawingView view, CompositeFigure group, Collection<Figure> figures) {
+        assert figures != null && figures.size() > 1 : "Fatal Invariant Violation: groupFigures called with insufficient figures.";
+
         Collection<Figure> sorted = view.getDrawing().sort(figures);
         int index = view.getDrawing().indexOf(sorted.iterator().next());
         view.getDrawing().basicRemoveAll(figures);

--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/GroupAction.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/GroupAction.java
@@ -25,6 +25,7 @@ public class GroupAction extends AbstractSelectedAction {
 
     private static final long serialVersionUID = 1L;
     public static final String ID = "edit.groupSelection";
+    private static final String LABELS_RESOURCE = "org.jhotdraw.draw.Labels";
     private CompositeFigure prototype;
     /**
      * If this variable is true, this action groups figures.
@@ -48,7 +49,7 @@ public class GroupAction extends AbstractSelectedAction {
         this.prototype = prototype;
         this.isGroupingAction = isGroupingAction;
         ResourceBundleUtil labels
-                = ResourceBundleUtil.getBundle("org.jhotdraw.draw.Labels");
+                = ResourceBundleUtil.getBundle(LABELS_RESOURCE);
         labels.configureAction(this, ID);
         updateEnabledState();
     }
@@ -87,7 +88,7 @@ public class GroupAction extends AbstractSelectedAction {
                     @Override
                     public String getPresentationName() {
                         ResourceBundleUtil labels
-                                = ResourceBundleUtil.getBundle("org.jhotdraw.draw.Labels");
+                                = ResourceBundleUtil.getBundle(LABELS_RESOURCE);
                         return labels.getString("edit.groupSelection.text");
                     }
 
@@ -101,11 +102,6 @@ public class GroupAction extends AbstractSelectedAction {
                     public void undo() throws CannotUndoException {
                         ungroupFigures(view, group);
                         super.undo();
-                    }
-
-                    @Override
-                    public boolean addEdit(UndoableEdit anEdit) {
-                        return super.addEdit(anEdit);
                     }
                 };
                 groupFigures(view, group, ungroupedFigures);
@@ -122,7 +118,7 @@ public class GroupAction extends AbstractSelectedAction {
                     @Override
                     public String getPresentationName() {
                         ResourceBundleUtil labels
-                                = ResourceBundleUtil.getBundle("org.jhotdraw.draw.Labels");
+                                = ResourceBundleUtil.getBundle(LABELS_RESOURCE);
                         return labels.getString("edit.ungroupSelection.text");
                     }
 

--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/GroupUndoableEdit.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/GroupUndoableEdit.java
@@ -1,0 +1,53 @@
+package org.jhotdraw.draw.action;
+
+import javax.swing.undo.AbstractUndoableEdit;
+import javax.swing.undo.CannotRedoException;
+import javax.swing.undo.CannotUndoException;
+import org.jhotdraw.draw.DrawingView;
+import org.jhotdraw.draw.figure.CompositeFigure;
+import org.jhotdraw.draw.figure.Figure;
+import java.util.Collection;
+import org.jhotdraw.util.ResourceBundleUtil;
+
+public class GroupUndoableEdit extends AbstractUndoableEdit {
+    private static final long serialVersionUID = 1L;
+    private final transient AbstractGroupAction action;
+    private final transient DrawingView view;
+    private final CompositeFigure group;
+    private final Collection<Figure> figures;
+    private final boolean isGrouping;
+
+    public GroupUndoableEdit(AbstractGroupAction action, DrawingView view, CompositeFigure group, Collection<Figure> figures, boolean isGrouping) {
+        this.action = action;
+        this.view = view;
+        this.group = group;
+        this.figures = figures;
+        this.isGrouping = isGrouping;
+    }
+
+    @Override
+    public String getPresentationName() {
+        ResourceBundleUtil labels = ResourceBundleUtil.getBundle(AbstractGroupAction.LABELS_RESOURCE);
+        return labels.getString(isGrouping ? "edit.groupSelection.text" : "edit.ungroupSelection.text");
+    }
+
+    @Override
+    public void redo() throws CannotRedoException {
+        super.redo();
+        if (isGrouping) {
+            action.groupFigures(view, group, figures);
+        } else {
+            action.ungroupFigures(view, group);
+        }
+    }
+
+    @Override
+    public void undo() throws CannotUndoException {
+        if (isGrouping) {
+            action.ungroupFigures(view, group);
+        } else {
+            action.groupFigures(view, group, figures);
+        }
+        super.undo();
+    }
+}

--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/UngroupAction.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/UngroupAction.java
@@ -1,41 +1,49 @@
-/*
- * @(#)UngroupAction.java
- *
- * Copyright (c) 1996-2010 The authors and contributors of JHotDraw.
- * You may not use, copy or modify this file, except in compliance with the
- * accompanying license terms.
- */
 package org.jhotdraw.draw.action;
 
+import org.jhotdraw.draw.figure.Figure;
 import org.jhotdraw.draw.figure.CompositeFigure;
 import org.jhotdraw.draw.figure.GroupFigure;
+import java.util.*;
+import javax.swing.undo.*;
 import org.jhotdraw.draw.*;
 import org.jhotdraw.util.ResourceBundleUtil;
 
-/**
- * UngroupAction.
- *
- * @author Werner Randelshofer
- * @version $Id$
- */
-public class UngroupAction extends GroupAction {
-
+public class UngroupAction extends AbstractGroupAction {
     private static final long serialVersionUID = 1L;
     public static final String ID = "edit.ungroupSelection";
-    /**
-     * Creates a new instance.
-     */
+
     public UngroupAction(DrawingEditor editor) {
-        super(editor, new GroupFigure(), false);
-        ResourceBundleUtil labels = ResourceBundleUtil.getBundle("org.jhotdraw.draw.Labels");
+        this(editor, new GroupFigure());
+    }
+
+    public UngroupAction(DrawingEditor editor, CompositeFigure prototype) {
+        super(editor, prototype);
+        ResourceBundleUtil labels = ResourceBundleUtil.getBundle(LABELS_RESOURCE);
         labels.configureAction(this, ID);
         updateEnabledState();
     }
 
-    public UngroupAction(DrawingEditor editor, CompositeFigure prototype) {
-        super(editor, prototype, false);
-        ResourceBundleUtil labels = ResourceBundleUtil.getBundle("org.jhotdraw.draw.Labels");
-        labels.configureAction(this, ID);
-        updateEnabledState();
+    @Override
+    protected void updateEnabledState() {
+        if (getView() != null) {
+            setEnabled(getView().getSelectionCount() == 1 
+                && prototype != null 
+                && getView().getSelectedFigures().iterator().next().getClass().equals(prototype.getClass()));
+        } else {
+            setEnabled(false);
+        }
+    }
+
+    @Override
+    public void actionPerformed(java.awt.event.ActionEvent e) {
+        if (isEnabled()) {
+            final DrawingView view = getView();
+            final CompositeFigure group = (CompositeFigure) getView().getSelectedFigures().iterator().next();
+            final LinkedList<Figure> ungroupedFigures = new LinkedList<>();
+
+            ungroupedFigures.addAll(ungroupFigures(view, group));
+            UndoableEdit edit = new GroupUndoableEdit(this, view, group, ungroupedFigures, false);
+            fireUndoableEditHappened(edit);
+        }
     }
 }

--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/UngroupAction.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/UngroupAction.java
@@ -25,11 +25,6 @@ public class UngroupAction extends GroupAction {
     /**
      * Creates a new instance.
      */
-    private CompositeFigure prototype;
-
-    /**
-     * Creates a new instance.
-     */
     public UngroupAction(DrawingEditor editor) {
         super(editor, new GroupFigure(), false);
         ResourceBundleUtil labels = ResourceBundleUtil.getBundle("org.jhotdraw.draw.Labels");

--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/figure/GroupFigure.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/figure/GroupFigure.java
@@ -1,48 +1,39 @@
-/*
- * @(#)GroupFigure.java
- *
- * Copyright (c) 1996-2010 The authors and contributors of JHotDraw.
- * You may not use, copy or modify this file, except in compliance with the
- * accompanying license terms.
- */
 package org.jhotdraw.draw.figure;
 
 import java.awt.geom.*;
 import org.jhotdraw.geom.Geom;
 
-/**
- * A {@link org.jhotdraw.draw.figure.Figure} which groups a collection of figures.
- *
- * @author Werner Randelshofer
- * @version $Id$
- */
 public class GroupFigure extends AbstractCompositeFigure {
 
     private static final long serialVersionUID = 1L;
 
-    /**
-     * Creates a new instance.
-     */
     public GroupFigure() {
         setConnectable(false);
     }
-
-    /**
-     * This is a default implementation that chops the point at the rectangle
-     * returned by getBounds() of the figure.
-     * <p>
-     * Figures which have a non-rectangular shape need to override this method.
-     * <p>
-     * FIXME Invoke chop on each child and return the closest point.
-     */
+    
     public Point2D.Double chop(Point2D.Double from) {
-        Rectangle2D.Double r = getBounds();
-        return Geom.angleToPoint(r, Geom.pointToAngle(r, from));
+        Point2D.Double closestPoint = null;
+        double minDistance = Double.MAX_VALUE;
+
+        for (Figure child : getChildren()) {
+            Rectangle2D.Double r = child.getBounds();
+            Point2D.Double chopped = Geom.angleToPoint(r, Geom.pointToAngle(r, from));
+            double distance = chopped.distanceSq(from); 
+            
+            if (distance < minDistance) {
+                minDistance = distance;
+                closestPoint = chopped;
+            }
+        }
+
+        if (closestPoint == null) {
+            Rectangle2D.Double r = getBounds();
+            return Geom.angleToPoint(r, Geom.pointToAngle(r, from));
+        }
+
+        return closestPoint;
     }
 
-    /**
-     * Returns true if all children of the group are transformable.
-     */
     @Override
     public boolean isTransformable() {
         for (Figure f : children) {

--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/figure/GroupFigure.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/figure/GroupFigure.java
@@ -19,18 +19,15 @@ public class GroupFigure extends AbstractCompositeFigure {
             Rectangle2D.Double r = child.getBounds();
             Point2D.Double chopped = Geom.angleToPoint(r, Geom.pointToAngle(r, from));
             double distance = chopped.distanceSq(from); 
-            
             if (distance < minDistance) {
                 minDistance = distance;
                 closestPoint = chopped;
             }
         }
-
         if (closestPoint == null) {
             Rectangle2D.Double r = getBounds();
             return Geom.angleToPoint(r, Geom.pointToAngle(r, from));
         }
-
         return closestPoint;
     }
 

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/action/GroupActionTest.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/action/GroupActionTest.java
@@ -7,20 +7,16 @@ import static org.junit.Assert.*;
 
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import org.jhotdraw.draw.DrawingEditor;
 import org.jhotdraw.draw.DrawingView;
 import org.jhotdraw.draw.Drawing;
-import org.jhotdraw.draw.figure.GroupFigure;
 import org.jhotdraw.draw.figure.CompositeFigure;
 import org.jhotdraw.draw.figure.Figure;
 
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -35,57 +31,29 @@ public class GroupActionTest {
 
     @Before
     public void setUp() {
-        groupAction = new GroupAction(mockEditor);
-
         when(mockEditor.getActiveView()).thenReturn(mockView);
+        groupAction = new GroupAction(mockEditor);
     }
 
     @Test
-    public void testCanGroupWithSufficientSelectionBestCase() {
+    public void testUpdateEnabledStateAllowsGroupingWithMultipleSelections() {
         when(mockView.getSelectionCount()).thenReturn(2);
-
-        boolean result = groupAction.canGroup();
-
-        assertTrue("Should be able to group with 2 or more items selected", result);
-        verify(mockView, times(1)).getSelectionCount();
+        groupAction.updateEnabledState();
+        assertTrue("Should be enabled with 2 or more items selected", groupAction.isEnabled());
     }
 
     @Test
-    public void testUngroupFiguresExecutionPath() {
-        CompositeFigure mockGroup = mock(CompositeFigure.class);
-        Collection<Figure> children = Arrays.asList(mockFigure1, mockFigure2);
-        
-        when(mockGroup.getChildren()).thenReturn(new LinkedList<>(children));
-        when(mockView.getDrawing()).thenReturn(mockDrawing);
-
-        Collection<Figure> result = groupAction.ungroupFigures(mockView, mockGroup);
-
-        verify(mockView).clearSelection();
-        verify(mockGroup).basicRemoveAllChildren();
-        verify(mockDrawing).remove(mockGroup);
-        verify(mockView).addToSelection(result);
-
-        assertEquals("Should successfully return the 2 extracted children", 2, result.size());
-    }
-
-    @Test
-    public void testCannotGroupWithOnlyOneSelection() {
+    public void testUpdateEnabledStateBlocksGroupingWithSingleSelection() {
         when(mockView.getSelectionCount()).thenReturn(1);
-
-        boolean canGroup = groupAction.canGroup();
-
-        assertFalse("Should not be able to group only 1 item", canGroup);
-
-        verify(mockView, times(1)).getSelectionCount();
+        groupAction.updateEnabledState();
+        assertFalse("Should be disabled with only 1 item selected", groupAction.isEnabled());
     }
 
     @Test
-    public void testGroupFiguresExecutionPath() {
-        // Setup mock figures and a fake collection
+    public void testAbstractGroupActionGroupFiguresExecutionPath() {
         List<Figure> figuresToGroup = Arrays.asList(mockFigure1, mockFigure2);
         CompositeFigure mockGroup = mock(CompositeFigure.class);
         
-        // Stub the drawing model
         when(mockView.getDrawing()).thenReturn(mockDrawing);
         when(mockDrawing.sort(figuresToGroup)).thenReturn(figuresToGroup);
         when(mockDrawing.indexOf(any())).thenReturn(0);
@@ -98,15 +66,5 @@ public class GroupActionTest {
         verify(mockGroup, times(1)).basicAdd(mockFigure1);
         verify(mockGroup, times(1)).basicAdd(mockFigure2);
         verify(mockView).addToSelection(mockGroup);
-    }
-
-    @Test
-    public void testCanUngroupFailsWithMultipleSelections() {
-        when(mockView.getSelectionCount()).thenReturn(2);
-
-        GroupAction ungroupAction = new GroupAction(mockEditor, new GroupFigure(), false);
-        boolean result = ungroupAction.canUngroup();
-
-        assertFalse("Should not be able to ungroup if multiple items are selected", result);
     }
 }

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/action/GroupActionTest.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/action/GroupActionTest.java
@@ -1,0 +1,112 @@
+package org.jhotdraw.draw.action;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.junit.Assert.*;
+
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import org.jhotdraw.draw.DrawingEditor;
+import org.jhotdraw.draw.DrawingView;
+import org.jhotdraw.draw.Drawing;
+import org.jhotdraw.draw.figure.GroupFigure;
+import org.jhotdraw.draw.figure.CompositeFigure;
+import org.jhotdraw.draw.figure.Figure;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GroupActionTest {
+    @Mock private DrawingView mockView;
+    @Mock private DrawingEditor mockEditor;
+    @Mock private Drawing mockDrawing;
+    @Mock private Figure mockFigure1;
+    @Mock private Figure mockFigure2;
+
+    private GroupAction groupAction;
+
+    @Before
+    public void setUp() {
+        groupAction = new GroupAction(mockEditor);
+
+        when(mockEditor.getActiveView()).thenReturn(mockView);
+    }
+
+    @Test
+    public void testCanGroupWithSufficientSelectionBestCase() {
+        when(mockView.getSelectionCount()).thenReturn(2);
+
+        boolean result = groupAction.canGroup();
+
+        assertTrue("Should be able to group with 2 or more items selected", result);
+        verify(mockView, times(1)).getSelectionCount();
+    }
+
+    @Test
+    public void testUngroupFiguresExecutionPath() {
+        CompositeFigure mockGroup = mock(CompositeFigure.class);
+        Collection<Figure> children = Arrays.asList(mockFigure1, mockFigure2);
+        
+        when(mockGroup.getChildren()).thenReturn(new LinkedList<>(children));
+        when(mockView.getDrawing()).thenReturn(mockDrawing);
+
+        Collection<Figure> result = groupAction.ungroupFigures(mockView, mockGroup);
+
+        verify(mockView).clearSelection();
+        verify(mockGroup).basicRemoveAllChildren();
+        verify(mockDrawing).remove(mockGroup);
+        verify(mockView).addToSelection(result);
+
+        assertEquals("Should successfully return the 2 extracted children", 2, result.size());
+    }
+
+    @Test
+    public void testCannotGroupWithOnlyOneSelection() {
+        when(mockView.getSelectionCount()).thenReturn(1);
+
+        boolean canGroup = groupAction.canGroup();
+
+        assertFalse("Should not be able to group only 1 item", canGroup);
+
+        verify(mockView, times(1)).getSelectionCount();
+    }
+
+    @Test
+    public void testGroupFiguresExecutionPath() {
+        // Setup mock figures and a fake collection
+        List<Figure> figuresToGroup = Arrays.asList(mockFigure1, mockFigure2);
+        CompositeFigure mockGroup = mock(CompositeFigure.class);
+        
+        // Stub the drawing model
+        when(mockView.getDrawing()).thenReturn(mockDrawing);
+        when(mockDrawing.sort(figuresToGroup)).thenReturn(figuresToGroup);
+        when(mockDrawing.indexOf(any())).thenReturn(0);
+
+        groupAction.groupFigures(mockView, mockGroup, figuresToGroup);
+
+        verify(mockDrawing).basicRemoveAll(figuresToGroup);
+        verify(mockView).clearSelection();
+        verify(mockDrawing).add(0, mockGroup);
+        verify(mockGroup, times(1)).basicAdd(mockFigure1);
+        verify(mockGroup, times(1)).basicAdd(mockFigure2);
+        verify(mockView).addToSelection(mockGroup);
+    }
+
+    @Test
+    public void testCanUngroupFailsWithMultipleSelections() {
+        when(mockView.getSelectionCount()).thenReturn(2);
+
+        GroupAction ungroupAction = new GroupAction(mockEditor, new GroupFigure(), false);
+        boolean result = ungroupAction.canUngroup();
+
+        assertFalse("Should not be able to ungroup if multiple items are selected", result);
+    }
+}

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/action/GroupFeatureBDDTest.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/action/GroupFeatureBDDTest.java
@@ -4,19 +4,13 @@ import com.tngtech.jgiven.Stage;
 import com.tngtech.jgiven.annotation.ExpectedScenarioState;
 import com.tngtech.jgiven.annotation.ProvidedScenarioState;
 import com.tngtech.jgiven.junit.ScenarioTest;
-
 import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.Test;
-
 import org.mockito.Mockito;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import org.jhotdraw.draw.DrawingEditor;
-import org.jhotdraw.draw.DrawingView;
-import org.jhotdraw.draw.Drawing;
+import org.jhotdraw.draw.*;
 import org.jhotdraw.draw.figure.Figure;
 import org.jhotdraw.draw.figure.GroupFigure;
 import org.jhotdraw.draw.figure.RectangleFigure;
@@ -65,13 +59,11 @@ public class GroupFeatureBDDTest extends ScenarioTest<
         @ExpectedScenarioState DrawingView mockView;
         @ExpectedScenarioState DrawingEditor mockEditor;
         @ExpectedScenarioState List<Figure> selectedFigures;
-
         @ProvidedScenarioState GroupFigure resultingGroup;
 
         public WhenUserActs the_group_action_is_executed() {
             GroupAction action = new GroupAction(mockEditor);
             resultingGroup = new GroupFigure();
-
             action.groupFigures(mockView, resultingGroup, selectedFigures);
             return this;
         }
@@ -79,24 +71,16 @@ public class GroupFeatureBDDTest extends ScenarioTest<
 
     public static class ThenCanvasState extends Stage<ThenCanvasState> {
         @ExpectedScenarioState GroupFigure resultingGroup;
-        @ExpectedScenarioState DrawingView mockView;
         @ExpectedScenarioState Drawing mockDrawing;
-        @ExpectedScenarioState List<Figure> selectedFigures;
 
         public ThenCanvasState a_single_group_is_created() {
-            assertThat(resultingGroup).
-                as("The resulting object must not be null and must be a GroupFigure")
-                .isNotNull()
-                .isInstanceOf(GroupFigure.class);
-
-            verify(mockDrawing).add(eq(0), eq(resultingGroup));
+            assertThat(resultingGroup).isNotNull().isInstanceOf(GroupFigure.class);
+            verify(mockDrawing).add(0, resultingGroup);
             return this;
         }
 
         public ThenCanvasState the_group_contains_exactly_two_items() {
-            assertThat(resultingGroup.getChildCount())
-                .as("The group must contain exactly the 2 selected items")
-                .isEqualTo(2);
+            assertThat(resultingGroup.getChildCount()).isEqualTo(2);
             return this;
         }
     }

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/action/GroupFeatureBDDTest.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/action/GroupFeatureBDDTest.java
@@ -1,0 +1,103 @@
+package org.jhotdraw.draw.action;
+
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import com.tngtech.jgiven.junit.ScenarioTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import org.jhotdraw.draw.DrawingEditor;
+import org.jhotdraw.draw.DrawingView;
+import org.jhotdraw.draw.Drawing;
+import org.jhotdraw.draw.figure.Figure;
+import org.jhotdraw.draw.figure.GroupFigure;
+import org.jhotdraw.draw.figure.RectangleFigure;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class GroupFeatureBDDTest extends ScenarioTest<
+        GroupFeatureBDDTest.GivenCanvasState,
+        GroupFeatureBDDTest.WhenUserActs,
+        GroupFeatureBDDTest.ThenCanvasState> {
+    
+    @Test
+    public void grouping_multiple_selected_figures_creates_a_single_group() {
+        given().two_individual_figures_are_selected_on_the_canvas();
+        when().the_group_action_is_executed();
+        then().a_single_group_is_created()
+            .and().the_group_contains_exactly_two_items();
+    }
+
+    public static class GivenCanvasState extends Stage<GivenCanvasState> {
+        @ProvidedScenarioState DrawingView mockView;
+        @ProvidedScenarioState DrawingEditor mockEditor;
+        @ProvidedScenarioState Drawing mockDrawing;
+        @ProvidedScenarioState List<Figure> selectedFigures;
+
+        public GivenCanvasState two_individual_figures_are_selected_on_the_canvas() {
+            mockView = mock(DrawingView.class);
+            mockEditor = mock(DrawingEditor.class);
+            mockDrawing = mock(Drawing.class);
+
+            Figure fig1 = new RectangleFigure();
+            Figure fig2 = new RectangleFigure();
+            selectedFigures = Arrays.asList(fig1, fig2);
+
+            Mockito.when(mockEditor.getActiveView()).thenReturn(mockView);
+            Mockito.when(mockView.getDrawing()).thenReturn(mockDrawing);
+            Mockito.when(mockView.getSelectionCount()).thenReturn(2);
+            Mockito.when(mockDrawing.sort(any())).thenReturn(selectedFigures);
+
+            return this;
+        }
+    }
+
+    public static class WhenUserActs extends Stage<WhenUserActs> {
+        @ExpectedScenarioState DrawingView mockView;
+        @ExpectedScenarioState DrawingEditor mockEditor;
+        @ExpectedScenarioState List<Figure> selectedFigures;
+
+        @ProvidedScenarioState GroupFigure resultingGroup;
+
+        public WhenUserActs the_group_action_is_executed() {
+            GroupAction action = new GroupAction(mockEditor);
+            resultingGroup = new GroupFigure();
+
+            action.groupFigures(mockView, resultingGroup, selectedFigures);
+            return this;
+        }
+    }
+
+    public static class ThenCanvasState extends Stage<ThenCanvasState> {
+        @ExpectedScenarioState GroupFigure resultingGroup;
+        @ExpectedScenarioState DrawingView mockView;
+        @ExpectedScenarioState Drawing mockDrawing;
+        @ExpectedScenarioState List<Figure> selectedFigures;
+
+        public ThenCanvasState a_single_group_is_created() {
+            assertThat(resultingGroup).
+                as("The resulting object must not be null and must be a GroupFigure")
+                .isNotNull()
+                .isInstanceOf(GroupFigure.class);
+
+            verify(mockDrawing).add(eq(0), eq(resultingGroup));
+            return this;
+        }
+
+        public ThenCanvasState the_group_contains_exactly_two_items() {
+            assertThat(resultingGroup.getChildCount())
+                .as("The group must contain exactly the 2 selected items")
+                .isEqualTo(2);
+            return this;
+        }
+    }
+}

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/action/GroupUndoableEditTest.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/action/GroupUndoableEditTest.java
@@ -1,0 +1,60 @@
+package org.jhotdraw.draw.action;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import static org.mockito.Mockito.*;
+
+import org.jhotdraw.draw.DrawingView;
+import org.jhotdraw.draw.figure.CompositeFigure;
+import org.jhotdraw.draw.figure.Figure;
+
+import java.util.Collection;
+import java.util.Arrays;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GroupUndoableEditTest {
+
+    @Mock private AbstractGroupAction mockAction;
+    @Mock private DrawingView mockView;
+    @Mock private CompositeFigure mockGroup;
+    @Mock private Figure mockFigure1;
+
+    private Collection<Figure> figures;
+
+    @Before
+    public void setUp() {
+        figures = Arrays.asList(mockFigure1);
+    }
+
+    @Test
+    public void testUndoGroupingTriggersUngroupMath() throws Exception {
+        GroupUndoableEdit edit = new GroupUndoableEdit(mockAction, mockView, mockGroup, figures, true);
+        
+        edit.undo();
+        
+        verify(mockAction, times(1)).ungroupFigures(mockView, mockGroup);
+    }
+
+    @Test
+    public void testRedoGroupingTriggersGroupMath() throws Exception {
+        GroupUndoableEdit edit = new GroupUndoableEdit(mockAction, mockView, mockGroup, figures, true);
+        
+        edit.undo(); 
+        edit.redo();
+
+        verify(mockAction, times(1)).groupFigures(mockView, mockGroup, figures);
+    }
+
+    @Test
+    public void testUndoUngroupingTriggersGroupMath() throws Exception {
+        GroupUndoableEdit edit = new GroupUndoableEdit(mockAction, mockView, mockGroup, figures, false);
+        
+        edit.undo();
+        
+        verify(mockAction, times(1)).groupFigures(mockView, mockGroup, figures);
+    }
+}

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/action/UngroupActionTest.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/action/UngroupActionTest.java
@@ -1,0 +1,75 @@
+package org.jhotdraw.draw.action;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.junit.Assert.*;
+
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import static org.mockito.Mockito.*;
+
+import org.jhotdraw.draw.DrawingEditor;
+import org.jhotdraw.draw.DrawingView;
+import org.jhotdraw.draw.Drawing;
+import org.jhotdraw.draw.figure.CompositeFigure;
+import org.jhotdraw.draw.figure.Figure;
+import org.jhotdraw.draw.figure.GroupFigure;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UngroupActionTest {
+    @Mock private DrawingView mockView;
+    @Mock private DrawingEditor mockEditor;
+    @Mock private Drawing mockDrawing;
+    @Mock private Figure mockFigure1;
+    @Mock private Figure mockFigure2;
+
+    private UngroupAction ungroupAction;
+
+    @Before
+    public void setUp() {
+        when(mockEditor.getActiveView()).thenReturn(mockView);
+        ungroupAction = new UngroupAction(mockEditor, new GroupFigure());
+    }
+
+    @Test
+    public void testUpdateEnabledStateFailsWithMultipleSelections() {
+        when(mockView.getSelectionCount()).thenReturn(2);
+        ungroupAction.updateEnabledState();
+        assertFalse("Should be disabled if multiple items are selected", ungroupAction.isEnabled());
+    }
+
+    @Test
+    public void testUpdateEnabledStateSucceedsWithSingleGroupFigure() {
+        when(mockView.getSelectionCount()).thenReturn(1);
+        
+        GroupFigure mockSelectedGroup = new GroupFigure();
+        when(mockView.getSelectedFigures()).thenReturn(Collections.singleton(mockSelectedGroup));
+
+        ungroupAction.updateEnabledState();
+        assertTrue("Should be enabled when exactly one group is selected", ungroupAction.isEnabled());
+    }
+
+    @Test
+    public void testUngroupFiguresExecutionPath() {
+        CompositeFigure mockGroup = mock(CompositeFigure.class);
+        Collection<Figure> children = Arrays.asList(mockFigure1, mockFigure2);
+        
+        when(mockGroup.getChildren()).thenReturn(new LinkedList<>(children));
+        when(mockView.getDrawing()).thenReturn(mockDrawing);
+
+        Collection<Figure> result = ungroupAction.ungroupFigures(mockView, mockGroup);
+
+        verify(mockView).clearSelection();
+        verify(mockGroup).basicRemoveAllChildren();
+        verify(mockDrawing).remove(mockGroup);
+        verify(mockView).addToSelection(result);
+
+        assertEquals("Should successfully return the 2 extracted children", 2, result.size());
+    }
+}

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/action/UngroupFeatureBDDTest.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/action/UngroupFeatureBDDTest.java
@@ -1,0 +1,90 @@
+package org.jhotdraw.draw.action;
+
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import com.tngtech.jgiven.junit.ScenarioTest;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.*;
+
+import org.jhotdraw.draw.*;
+import org.jhotdraw.draw.figure.Figure;
+import org.jhotdraw.draw.figure.GroupFigure;
+import org.jhotdraw.draw.figure.RectangleFigure;
+
+import java.util.Collection;
+
+public class UngroupFeatureBDDTest extends ScenarioTest<
+        UngroupFeatureBDDTest.GivenCanvasState,
+        UngroupFeatureBDDTest.WhenUserActs,
+        UngroupFeatureBDDTest.ThenCanvasState> {
+
+    @Test
+    public void ungrouping_a_selected_group_restores_individual_figures() {
+        given().a_single_group_containing_two_figures_is_selected();
+        when().the_ungroup_action_is_executed();
+        then().the_group_is_dissolved_from_the_canvas()
+            .and().the_individual_figures_are_restored();
+    }
+
+    public static class GivenCanvasState extends Stage<GivenCanvasState> {
+        @ProvidedScenarioState DrawingView mockView;
+        @ProvidedScenarioState DrawingEditor mockEditor;
+        @ProvidedScenarioState Drawing mockDrawing;
+        @ProvidedScenarioState GroupFigure mockSelectedGroup;
+
+        public GivenCanvasState a_single_group_containing_two_figures_is_selected() {
+            mockView = mock(DrawingView.class);
+            mockEditor = mock(DrawingEditor.class);
+            mockDrawing = mock(Drawing.class);
+            mockSelectedGroup = new GroupFigure();
+            
+            mockSelectedGroup.add(new RectangleFigure());
+            mockSelectedGroup.add(new RectangleFigure());
+
+            Mockito.when(mockEditor.getActiveView()).thenReturn(mockView);
+            Mockito.when(mockView.getDrawing()).thenReturn(mockDrawing);
+            Mockito.when(mockView.getSelectionCount()).thenReturn(1);
+            
+            java.util.Set<Figure> selectedSet = new java.util.HashSet<>();
+            selectedSet.add(mockSelectedGroup);
+            Mockito.when(mockView.getSelectedFigures()).thenReturn(selectedSet);
+            
+            Mockito.when(mockDrawing.indexOf(mockSelectedGroup)).thenReturn(0);
+
+            return this;
+        }
+    }
+
+    public static class WhenUserActs extends Stage<WhenUserActs> {
+        @ExpectedScenarioState DrawingView mockView;
+        @ExpectedScenarioState DrawingEditor mockEditor;
+        @ExpectedScenarioState GroupFigure mockSelectedGroup;
+        @ProvidedScenarioState Collection<Figure> restoredFigures;
+
+        public WhenUserActs the_ungroup_action_is_executed() {
+            UngroupAction action = new UngroupAction(mockEditor);
+            restoredFigures = action.ungroupFigures(mockView, mockSelectedGroup);
+            return this;
+        }
+    }
+
+    public static class ThenCanvasState extends Stage<ThenCanvasState> {
+        @ExpectedScenarioState Drawing mockDrawing;
+        @ExpectedScenarioState GroupFigure mockSelectedGroup;
+        @ExpectedScenarioState Collection<Figure> restoredFigures;
+
+        public ThenCanvasState the_group_is_dissolved_from_the_canvas() {
+            verify(mockDrawing).remove(mockSelectedGroup);
+            return this;
+        }
+
+        public ThenCanvasState the_individual_figures_are_restored() {
+            assertThat(restoredFigures).hasSize(2);
+            verify(mockDrawing).basicAddAll(0, restoredFigures);
+            return this;
+        }
+    }
+}

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/figure/GroupFigureTest.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/figure/GroupFigureTest.java
@@ -1,0 +1,60 @@
+package org.jhotdraw.draw.figure;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+
+public class GroupFigureTest {
+    private GroupFigure groupFigure;
+    private Figure testChild;
+
+    @Before
+    public void setUp() {
+        groupFigure = new GroupFigure();
+        testChild = new RectangleFigure();
+    }
+
+    @Test
+    public void testBasicAddBestCase() {
+        groupFigure.basicAdd(testChild);
+
+        assertEquals("The group should contain exactly 1 child", 1, groupFigure.getChildCount());
+        assertTrue("Group should successfully contain the specific testChild", groupFigure.getChildren().contains(testChild));
+    }
+
+    @Test
+    public void testBasicRemoveBoundaryCase() {
+        int initialCount = groupFigure.getChildCount();
+        
+        groupFigure.basicRemove(testChild);
+        
+        assertEquals("Child count should safely remain 0 without crashing", 0, initialCount);
+        assertEquals(0, groupFigure.getChildCount());
+    }
+
+    @Test
+    public void testIsTransformableState() {
+        groupFigure.basicAdd(testChild);
+        
+        assertEquals("Group transformable state must match child state", 
+                     testChild.isTransformable(), 
+                     groupFigure.isTransformable());
+    }
+
+    @Test
+    public void testCloneCreatesIndependentCopy() {
+        groupFigure.basicAdd(testChild);
+
+        GroupFigure clonedGroup = (GroupFigure) groupFigure.clone();
+
+        assertNotSame("Cloned group should be a distinct memory instance", groupFigure, clonedGroup);
+        assertEquals("Cloned group should have the same number of children", 
+                     groupFigure.getChildCount(), 
+                     clonedGroup.getChildCount());
+
+        clonedGroup.basicRemoveAllChildren();
+        assertEquals("Original group should retain its children after clone is cleared", 1, groupFigure.getChildCount());
+        assertEquals("Cloned group should be empty", 0, clonedGroup.getChildCount());
+    }
+}

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/figure/GroupFigureTest.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/figure/GroupFigureTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+import java.awt.geom.Point2D;
 
 public class GroupFigureTest {
     private GroupFigure groupFigure;
@@ -76,7 +77,6 @@ public class GroupFigureTest {
         innerGroup.basicAdd(testChild);
         
         GroupFigure outerGroup = new GroupFigure();
-        
         outerGroup.basicAdd(innerGroup);
         
         assertEquals("Outer group should contain exactly 1 child (the inner group)", 1, outerGroup.getChildCount());
@@ -84,5 +84,25 @@ public class GroupFigureTest {
         
         GroupFigure retrievedInnerGroup = (GroupFigure) outerGroup.getChildren().iterator().next();
         assertTrue("Inner group must still contain the original shape", retrievedInnerGroup.getChildren().contains(testChild));
+    }
+
+    @Test
+    public void testChopMethodCalculatesGeometricIntersection() {
+        RectangleFigure rect1 = new RectangleFigure();
+        rect1.setBounds(new Point2D.Double(0, 0), new Point2D.Double(10, 10));
+
+        RectangleFigure rect2 = new RectangleFigure();
+        rect2.setBounds(new Point2D.Double(100, 100), new Point2D.Double(110, 110));
+
+        groupFigure.basicAdd(rect1);
+        groupFigure.basicAdd(rect2);
+
+        Point2D.Double fromPoint = new Point2D.Double(500, 500);
+
+        Point2D.Double result = groupFigure.chop(fromPoint);
+
+        assertNotNull("Chop should return a valid mathematical intersection point", result);
+
+        assertTrue("Chop should snap to the closest child geometry", result.x > 50);
     }
 }

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/figure/GroupFigureTest.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/figure/GroupFigureTest.java
@@ -8,11 +8,13 @@ import static org.junit.Assert.*;
 public class GroupFigureTest {
     private GroupFigure groupFigure;
     private Figure testChild;
+    private Figure testChild2;
 
     @Before
     public void setUp() {
         groupFigure = new GroupFigure();
         testChild = new RectangleFigure();
+        testChild2 = new TextFigure();
     }
 
     @Test
@@ -21,6 +23,16 @@ public class GroupFigureTest {
 
         assertEquals("The group should contain exactly 1 child", 1, groupFigure.getChildCount());
         assertTrue("Group should successfully contain the specific testChild", groupFigure.getChildren().contains(testChild));
+    }
+
+    @Test
+    public void testGroupDifferentFigureTypes() {
+        groupFigure.basicAdd(testChild);
+        groupFigure.basicAdd(testChild2);
+
+        assertEquals("Group should hold exactly 2 children", 2, groupFigure.getChildCount());
+        assertTrue("Group must contain the rectangle figure", groupFigure.getChildren().contains(testChild));
+        assertTrue("Group must contain the text figure", groupFigure.getChildren().contains(testChild2));
     }
 
     @Test
@@ -56,5 +68,21 @@ public class GroupFigureTest {
         clonedGroup.basicRemoveAllChildren();
         assertEquals("Original group should retain its children after clone is cleared", 1, groupFigure.getChildCount());
         assertEquals("Cloned group should be empty", 0, clonedGroup.getChildCount());
+    }
+
+    @Test
+    public void testNestedGrouping() {
+        GroupFigure innerGroup = new GroupFigure();
+        innerGroup.basicAdd(testChild);
+        
+        GroupFigure outerGroup = new GroupFigure();
+        
+        outerGroup.basicAdd(innerGroup);
+        
+        assertEquals("Outer group should contain exactly 1 child (the inner group)", 1, outerGroup.getChildCount());
+        assertTrue("Outer group must contain the inner group", outerGroup.getChildren().contains(innerGroup));
+        
+        GroupFigure retrievedInnerGroup = (GroupFigure) outerGroup.getChildren().iterator().next();
+        assertTrue("Inner group must still contain the original shape", retrievedInnerGroup.getChildren().contains(testChild));
     }
 }

--- a/jhotdraw-samples/jhotdraw-samples-misc/src/main/java/org/jhotdraw/samples/odg/action/CombineAction.java
+++ b/jhotdraw-samples/jhotdraw-samples-misc/src/main/java/org/jhotdraw/samples/odg/action/CombineAction.java
@@ -36,40 +36,21 @@ public class CombineAction extends GroupAction {
         labels.configureAction(this, ID);
     }
 
+
     @Override
-    protected boolean canGroup() {
-        boolean canCombine = getView().getSelectionCount() > 1;
-        if (canCombine) {
+    protected void updateEnabledState() {
+        super.updateEnabledState(); 
+        
+        if (isEnabled()) {
+            boolean canCombine = true;
             for (Figure f : getView().getSelectedFigures()) {
                 if (!(f instanceof ODGPathFigure)) {
                     canCombine = false;
                     break;
                 }
             }
+            setEnabled(canCombine);
         }
-        return canCombine;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public Collection<Figure> ungroupFigures(DrawingView view, CompositeFigure group) {
-        LinkedList<Figure> figures = new LinkedList<Figure>(group.getChildren());
-        view.clearSelection();
-        group.basicRemoveAllChildren();
-        LinkedList<Figure> paths = new LinkedList<Figure>();
-        for (Figure f : figures) {
-            ODGPathFigure path = new ODGPathFigure();
-            path.removeAllChildren();
-            for (Map.Entry<AttributeKey<?>, Object> entry : group.getAttributes().entrySet()) {
-                path.set((AttributeKey<Object>) entry.getKey(), entry.getValue());
-            }
-            path.add(f);
-            view.getDrawing().basicAdd(path);
-            paths.add(path);
-        }
-        view.getDrawing().remove(group);
-        view.addToSelection(paths);
-        return figures;
     }
 
     @Override

--- a/jhotdraw-samples/jhotdraw-samples-misc/src/main/java/org/jhotdraw/samples/odg/action/SplitAction.java
+++ b/jhotdraw-samples/jhotdraw-samples-misc/src/main/java/org/jhotdraw/samples/odg/action/SplitAction.java
@@ -37,11 +37,15 @@ public class SplitAction extends UngroupAction {
     }
 
     @Override
-    protected boolean canUngroup() {
-        if (super.canUngroup()) {
-            return ((CompositeFigure) getView().getSelectedFigures().iterator().next()).getChildCount() > 1;
+    protected void updateEnabledState() {
+        super.updateEnabledState(); 
+        
+        if (isEnabled()) {
+            CompositeFigure group = (CompositeFigure) getView().getSelectedFigures().iterator().next();
+            if (group.getChildCount() <= 1) {
+                setEnabled(false);
+            }
         }
-        return false;
     }
 
     @SuppressWarnings("unchecked")
@@ -64,27 +68,5 @@ public class SplitAction extends UngroupAction {
         view.getDrawing().remove(group);
         view.addToSelection(paths);
         return figures;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public void groupFigures(DrawingView view, CompositeFigure group, Collection<Figure> figures) {
-        Collection<Figure> sorted = view.getDrawing().sort(figures);
-        view.getDrawing().basicRemoveAll(figures);
-        view.clearSelection();
-        view.getDrawing().add(group);
-        group.willChange();
-        ((ODGPathFigure) group).removeAllChildren();
-        for (Map.Entry<AttributeKey<?>, Object> entry : figures.iterator().next().getAttributes().entrySet()) {
-            group.set((AttributeKey<Object>) entry.getKey(), entry.getValue());
-        }
-        for (Figure f : sorted) {
-            ODGPathFigure path = (ODGPathFigure) f;
-            for (Figure child : path.getChildren()) {
-                group.basicAdd(child);
-            }
-        }
-        group.changed();
-        view.addToSelection(group);
     }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the grouping and ungrouping functionality in the drawing application, with a focus on refactoring for better code reuse, adding undo/redo support, and improving testability. The changes include the introduction of a shared abstract action for grouping logic, a new undoable edit class, and the addition of comprehensive unit tests. There are also updates to the build configuration and dependencies to support modern development workflows and testing.

### Group/Ungroup Refactor and Undo/Redo Support

* Introduced `AbstractGroupAction` to encapsulate shared logic for grouping and ungrouping figures, reducing code duplication in `GroupAction` and `UngroupAction`. (`jhotdraw-core/src/main/java/org/jhotdraw/draw/action/AbstractGroupAction.java`)
* Refactored `GroupAction` and `UngroupAction` to extend `AbstractGroupAction`, simplifying their code and aligning their behaviors. (`jhotdraw-core/src/main/java/org/jhotdraw/draw/action/GroupAction.java`, `jhotdraw-core/src/main/java/org/jhotdraw/draw/action/UngroupAction.java`) [[1]](diffhunk://#diff-7f1e9fc68f968bf4a67562fdf1cc65b29c73c0586bbae0460efc017306dee6b4L18-L170) [[2]](diffhunk://#diff-fd9d0e09a85fc6ab635c83ca4c17dcf1a224d889715ded0fe0faacdd61131360L1-R48)
* Added `GroupUndoableEdit` to handle undo/redo for both grouping and ungrouping actions, improving user experience and code maintainability. (`jhotdraw-core/src/main/java/org/jhotdraw/draw/action/GroupUndoableEdit.java`)

### Testing Improvements

* Added unit tests for `GroupAction`, including state and behavior verification using Mockito, to ensure reliability and facilitate future changes. (`jhotdraw-core/src/test/java/org/jhotdraw/draw/action/GroupActionTest.java`)

### Build and Dependency Updates

* Updated Maven configuration to add modern test dependencies (`junit`, `mockito-core`, `jgiven-junit`, `assertj-core`) and configured the `maven-surefire-plugin` for compatibility with Java 17. (`jhotdraw-core/pom.xml`)
* Added a Maven settings file for GitHub authentication and a GitHub Actions CI workflow for automated builds and tests on pushes and pull requests. (`.maven-settings.xml`, `.github/workflows/ci.yml`) [[1]](diffhunk://#diff-f03c9e283196ec01ae0a50ebc003454a84a35eb6620552acf3fba03880e3efbbR1-R9) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R26)
* Added VSCode settings to enable interactive Java build configuration updates. (`.vscode/settings.json`)

### Group Figure Logic Enhancement

* Improved the `GroupFigure.chop` method to select the closest child figure's chop point, enhancing geometric accuracy when connecting to grouped figures. (`jhotdraw-core/src/main/java/org/jhotdraw/draw/figure/GroupFigure.java`)